### PR TITLE
Use built in JSON serialisation instead of hand crafting

### DIFF
--- a/asset-register-api/Controllers/AssetController.cs
+++ b/asset-register-api/Controllers/AssetController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using asset_register_api.HomesEngland.Exception;
 using asset_register_api.Interface.UseCase;
@@ -7,6 +6,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace asset_register_api.Controllers
 {
+    using Asset = Dictionary<string,string>;
+
     [Route("[controller]")]
     [ApiController]
     public class AssetController : ControllerBase
@@ -16,37 +17,19 @@ namespace asset_register_api.Controllers
         {
             _assetUseCase = useCase;
         }
-        
+
         [HttpGet("{id}")]
-        public async Task<ActionResult<string>> Get(int id)
-        { 
+        [Produces("application/json")]
+        public async Task<ActionResult<Asset>> Get(int id)
+        {
             try
             {
-                Dictionary<string,string> result = await _assetUseCase.Execute(id);
-                return ConvertToJson(result);   
+                return await _assetUseCase.Execute(id);
             }
             catch (NoAssetException)
             {
-                return "{}";
+                return new Asset();
             }
-          
-        }
-
-        private static string ConvertToJson(Dictionary<string, string> result)
-        {
-            string quoteMark = "\"";
-            string expectedResult = "{";
-            foreach (string key in result.Keys)
-            {
-                expectedResult += quoteMark + key + quoteMark + ":" + quoteMark + result[key] + quoteMark+",";
-            }
-            expectedResult =  RemoveLastComma(expectedResult)+"}";
-            return expectedResult;
-        }
-        
-        private static string RemoveLastComma(string expectedResult)
-        {
-            return expectedResult.Remove(expectedResult.Length - 1);
         }
     }
 }

--- a/asset-register-api/Controllers/AssetsController.cs
+++ b/asset-register-api/Controllers/AssetsController.cs
@@ -3,8 +3,12 @@ using System.Threading.Tasks;
 using asset_register_api.Interface.UseCase;
 using Microsoft.AspNetCore.Mvc;
 
+
+
 namespace asset_register_api.Controllers
 {
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     [Route("[controller]")]
     [ApiController]
     public class AssetsController : ControllerBase
@@ -14,49 +18,22 @@ namespace asset_register_api.Controllers
         {
             _assetsUseCase = useCase;
         }
-        
+
         [HttpGet]
-        public async Task<ActionResult<string>> Get(int[] ids)
-        { 
-            return GetExpectedResult( await _assetsUseCase.Execute(ids));
-        }
-        private string GetExpectedResult( Dictionary<string, string>[] results)
+        [Produces("application/json")]
+        public async Task<ActionResult<AssetsDictionary>> Get(int[] ids)
         {
-            return GetAssetsJsonArray(results);
+            return GetWrappedAssets( await _assetsUseCase.Execute(ids));
         }
 
-        private static string GetAssetsJsonArray(Dictionary<string, string>[] results)
+        private static AssetsDictionary GetWrappedAssets(Dictionary<string, string>[] results)
         {
-            if (results.Length == 0)
+            return new AssetsDictionary
             {
-                return "{\"Assets\":[]}";
-            }
-            
-            string expectedResult = "{\"Assets\":[";
-            foreach (var asset in results)
-            {
-                expectedResult = GetJsonAsset(expectedResult, asset);
-            }
-            
-            expectedResult = RemoveLastComma(expectedResult) + "]}";
-            return expectedResult;
-        }
-
-        private static string RemoveLastComma(string expectedResult)
-        {
-            return expectedResult.Remove(expectedResult.Length - 1);
-        }
-
-        private static string GetJsonAsset(string expectedResult, Dictionary<string, string> asset)
-        {
-            expectedResult += "{";
-            foreach (string key in asset.Keys)
-            {
-                expectedResult += "\"" + key + "\":\"" + asset[key] + "\",";
-            }
-
-            expectedResult = RemoveLastComma(expectedResult) + "},";
-            return expectedResult;
+                {
+                    "Assets", results
+                }
+            };
         }
     }
 }

--- a/asset-register-api/Controllers/SearchController.cs
+++ b/asset-register-api/Controllers/SearchController.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using asset_register_api.Interface.UseCase;
 using Microsoft.AspNetCore.Mvc;
 
 namespace asset_register_api.Controllers
 {
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     [Route("[controller]")]
     [ApiController]
     public class SearchController : Controller
@@ -15,46 +16,22 @@ namespace asset_register_api.Controllers
         {
             UseCase = useCase;
         }
-        
+
         [HttpGet]
-        public async Task<ActionResult<string>> Get(string query)
+        [Produces("application/json")]
+        public async Task<ActionResult<AssetsDictionary>> Get(string query)
         {
-            return GetExpectedResult( await UseCase.Execute(query));
-        }
-        
-        private string GetExpectedResult( Dictionary<string, string>[] results)
-        {
-            return GetAssetsJsonArray(results);
+            return GetWrappedAssets( await UseCase.Execute(query));
         }
 
-        private static string GetAssetsJsonArray(Dictionary<string, string>[] results)
+        private static AssetsDictionary GetWrappedAssets(Dictionary<string, string>[] results)
         {
-            if (results.Length == 0)
+            return new AssetsDictionary
             {
-                return "{\"Assets\":[]}";
-            }
-            
-            string expectedResult = results.Aggregate("{\"Assets\":[", (current, asset) => GetJsonAsset(current, asset));
-
-            expectedResult = RemoveLastComma(expectedResult) + "]}";
-            return expectedResult;
-        }
-        
-        private static string RemoveLastComma(string expectedResult)
-        {
-            return expectedResult.Remove(expectedResult.Length - 1);
-        }
-
-        private static string GetJsonAsset(string expectedResult, Dictionary<string, string> asset)
-        {
-            expectedResult += "{";
-            foreach (string key in asset.Keys)
-            {
-                expectedResult += "\"" + key + "\":\"" + asset[key] + "\",";
-            }
-
-            expectedResult = RemoveLastComma(expectedResult) + "},";
-            return expectedResult;
+                {
+                    "Assets", results
+                }
+            };
         }
     }
 }

--- a/asset-register-tests/HomesEngland/Controller/GetAsset/GetAssetControllerTest.cs
+++ b/asset-register-tests/HomesEngland/Controller/GetAsset/GetAssetControllerTest.cs
@@ -1,14 +1,16 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using asset_register_api.Controllers;
 using asset_register_api.HomesEngland.Domain;
 using asset_register_api.Interface.UseCase;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace asset_register_tests.HomesEngland.Controller.GetAsset
 {
+    using AssetDictionary = Dictionary<string, string>;
+
     [TestFixture]
     public abstract class GetAssetControllerTest
     {
@@ -18,7 +20,7 @@ namespace asset_register_tests.HomesEngland.Controller.GetAsset
         protected abstract string AssetAccountingYear { get; }
         private Mock<IGetAssetUseCase> _mock;
         private AssetController _controller;
-        
+
         [SetUp]
         public void SetUp()
         {
@@ -29,36 +31,36 @@ namespace asset_register_tests.HomesEngland.Controller.GetAsset
                 AccountingYear = AssetAccountingYear,
                 SchemeID = AssetSchemeID
             }).ToDictionary());
-            
+
             _controller = new AssetController(_mock.Object);
         }
-        
+
         [Test]
         public async Task GetAssetControllerCallsUseCase()
         {
             await _controller.Get(AssetId);
-            _mock.Verify(mock => mock.Execute(AssetId), Times.Once());  
+            _mock.Verify(mock => mock.Execute(AssetId), Times.Once());
         }
-        
+
         [Test]
         public async Task GetAssetControllerReturnsJson()
         {
-            ActionResult<string> returnedData = await _controller.Get(AssetId);
-            JObject assetAsJson = JObject.Parse(returnedData.Value);
-         
+            ActionResult<AssetDictionary> returnedData = await _controller.Get(AssetId);
+            AssetDictionary assetAsJson = returnedData.Value;
+
             if(assetAsJson["Address"]!=null)
             {
-                Assert.True(AssetAddress == assetAsJson["Address"].ToString());
+                Assert.True(AssetAddress == assetAsJson["Address"]);
             }
             if(assetAsJson["SchemeID"]!=null)
             {
-                Assert.True(AssetSchemeID == assetAsJson["SchemeID"].ToString());
+                Assert.True(AssetSchemeID == assetAsJson["SchemeID"]);
             }
             if(assetAsJson["AccountingYear"]!=null)
             {
-                Assert.True(AssetAccountingYear == assetAsJson["AccountingYear"].ToString());
+                Assert.True(AssetAccountingYear == assetAsJson["AccountingYear"]);
             }
         }
-        
+
     }
 }

--- a/asset-register-tests/HomesEngland/Controller/GetAssets/GetAssetsControllerTest.cs
+++ b/asset-register-tests/HomesEngland/Controller/GetAssets/GetAssetsControllerTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using asset_register_api.Controllers;
@@ -5,11 +6,13 @@ using asset_register_api.HomesEngland.Domain;
 using asset_register_api.Interface.UseCase;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace asset_register_tests.HomesEngland.Controller.GetAssets
 {
+    using AssetDictionary = Dictionary<string, string>;
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     [TestFixture]
     public abstract class GetAssetsControllerTest
     {
@@ -39,21 +42,21 @@ namespace asset_register_tests.HomesEngland.Controller.GetAssets
         [Test]
         public async Task GetAssetControllerReturnsJson()
         {
-            ActionResult<string> returnedData = await _controller.Get(AssetIds);
-            JObject json = JObject.Parse(returnedData.Value);
-            foreach (var assetAsJson in json.GetValue("Assets"))
+            ActionResult<AssetsDictionary> returnedData = await _controller.Get(AssetIds);
+            AssetsDictionary json = returnedData.Value;
+            foreach (AssetDictionary assetAsJson in json["Assets"])
             {
                 if(assetAsJson["Address"]!=null)
                 {
-                    Assert.True(Assets.Any(_=>_.Address == assetAsJson["Address"].ToString()));
+                    Assert.True(Assets.Any(_=>_.Address == assetAsJson["Address"]));
                 }
                 if(assetAsJson["SchemeID"]!=null)
                 {
-                    Assert.True(Assets.Any(_=>_.SchemeID == assetAsJson["SchemeID"].ToString()));
+                    Assert.True(Assets.Any(_=>_.SchemeID == assetAsJson["SchemeID"]));
                 }
                 if(assetAsJson["AccountingYear"]!=null)
                 {
-                    Assert.True(Assets.Any(_=>_.AccountingYear == assetAsJson["AccountingYear"].ToString()));
+                    Assert.True(Assets.Any(_=>_.AccountingYear == assetAsJson["AccountingYear"]));
                 }
             }
         }

--- a/asset-register-tests/HomesEngland/Controller/GetAssets/NoAssets/GetAssetsControllerNoAssetsTest.cs
+++ b/asset-register-tests/HomesEngland/Controller/GetAssets/NoAssets/GetAssetsControllerNoAssetsTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using asset_register_api.Controllers;
@@ -8,6 +9,9 @@ using NUnit.Framework;
 
 namespace asset_register_tests.HomesEngland.Controller.GetAssets
 {
+    using AssetDictionary = Dictionary<string, string>;
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     [TestFixture]
     public class GetAssetsControllerNoAssetsTest
     {
@@ -28,8 +32,13 @@ namespace asset_register_tests.HomesEngland.Controller.GetAssets
         [Test]
         public async Task ReturnsJsonWithEmptyAssetsArray()
         {
-            ActionResult<string> controllerResult = await  _controller.Get(AssetIds);
-            Assert.AreEqual(controllerResult.Value, "{\"Assets\":[]}");
+            ActionResult<AssetsDictionary> controllerResult = await  _controller.Get(AssetIds);
+            Assert.AreEqual(
+                controllerResult.Value,
+                new AssetsDictionary {
+                    {"Assets", new AssetDictionary[0]}
+                }
+            );
         }
     }
 }

--- a/asset-register-tests/HomesEngland/Controller/SearchAssets/NoAssets/SearchAssetsControllerNoAssetsTest.cs
+++ b/asset-register-tests/HomesEngland/Controller/SearchAssets/NoAssets/SearchAssetsControllerNoAssetsTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using asset_register_api.Controllers;
@@ -9,13 +10,16 @@ using NUnit.Framework;
 
 namespace asset_register_tests.HomesEngland.Controller.SearchAssets.NoAssets
 {
+    using AssetDictionary = Dictionary<string, string>;
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     public class SearchAssetsControllerNoAssetsTest
     {
         private Mock<ISearchAssetsUseCase> _mock;
         private SearchController _controller;
         protected Asset[] SearchResults => new Asset[0];
         private string SearchQuery => "Search";
-        
+
         [SetUp]
         public void SetUp()
         {
@@ -23,14 +27,19 @@ namespace asset_register_tests.HomesEngland.Controller.SearchAssets.NoAssets
             _mock.Setup(useCase => useCase.Execute(SearchQuery)).ReturnsAsync(() => SearchResults.ToList().Select(_=>_.ToDictionary()).ToArray());
             _controller = new SearchController(_mock.Object);
         }
-        
+
         [Test]
         public async Task ReturnsJsonWithEmptyAssetsArray()
         {
-            ActionResult<string> controllerResult = await  _controller.Get(SearchQuery);
-            Assert.AreEqual(controllerResult.Value, "{\"Assets\":[]}");
+            ActionResult<AssetsDictionary> controllerResult = await  _controller.Get(SearchQuery);
+            Assert.AreEqual(
+                controllerResult.Value,
+                new AssetsDictionary {
+                    {"Assets", new AssetDictionary[0]}
+                }
+            );
         }
-        
-     
+
+
     }
 }

--- a/asset-register-tests/HomesEngland/Controller/SearchAssets/SearchAssetsControllerTest.cs
+++ b/asset-register-tests/HomesEngland/Controller/SearchAssets/SearchAssetsControllerTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using asset_register_api.Controllers;
@@ -10,13 +11,16 @@ using NUnit.Framework;
 
 namespace asset_register_tests.HomesEngland.Controller.SearchAssets
 {
+    using AssetDictionary = Dictionary<string, string>;
+    using AssetsDictionary = Dictionary<string, Dictionary<string, string>[]>;
+
     public abstract class SearchAssetsControllerTest
     {
         private Mock<ISearchAssetsUseCase> _mock;
         private SearchController _controller;
         protected abstract Asset[] SearchResults { get; }
         private string SearchQuery => "Search";
-        
+
         [SetUp]
         public void SetUp()
         {
@@ -24,32 +28,32 @@ namespace asset_register_tests.HomesEngland.Controller.SearchAssets
             _mock.Setup(useCase => useCase.Execute(SearchQuery)).ReturnsAsync(() => SearchResults.ToList().Select(_=>_.ToDictionary()).ToArray());
             _controller = new SearchController(_mock.Object);
         }
-        
+
         [Test]
         public async Task SearchAssetControllerCallsUseCase()
         {
             await _controller.Get(SearchQuery);
             _mock.Verify(mock => mock.Execute(SearchQuery), Times.Once());
         }
-        
+
         [Test]
         public async Task GetAssetControllerReturnsJson()
         {
-            ActionResult<string> returnedData = await _controller.Get(SearchQuery);
-            JObject json = JObject.Parse(returnedData.Value);
-            foreach (var assetAsJson in json.GetValue("Assets"))
+            ActionResult<AssetsDictionary> returnedData = await _controller.Get(SearchQuery);
+            AssetsDictionary json = returnedData.Value;
+            foreach (AssetDictionary assetAsJson in json["Assets"])
             {
                 if(assetAsJson["Address"]!=null)
                 {
-                    Assert.True(SearchResults.Any(_=>_.Address == assetAsJson["Address"].ToString()));
+                    Assert.True(SearchResults.Any(_=>_.Address == assetAsJson["Address"]));
                 }
                 if(assetAsJson["SchemeID"]!=null)
                 {
-                    Assert.True(SearchResults.Any(_=>_.SchemeID == assetAsJson["SchemeID"].ToString()));
+                    Assert.True(SearchResults.Any(_=>_.SchemeID == assetAsJson["SchemeID"]));
                 }
                 if(assetAsJson["AccountingYear"]!=null)
                 {
-                    Assert.True(SearchResults.Any(_=>_.AccountingYear == assetAsJson["AccountingYear"].ToString()));
+                    Assert.True(SearchResults.Any(_=>_.AccountingYear == assetAsJson["AccountingYear"]));
                 }
             }
         }


### PR DESCRIPTION
closes #17 

Make use of `[Produces('application/json')]`. Controllers now return actual objects, and we let the framework do the work.

We can move to a more explicit form where strings are always returned if you'd prefer