### PR TITLE
Ignore published out directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ __pycache__/
 
 # Cake - Uncomment if you are using it
 # tools/
+
+# Directories created from dotnet publish
+*/out


### PR DESCRIPTION
When running our `dotnet publish` commands, `out` directories are created which we don't need to track.