### PR TITLE
Fix deployments with restructure

### DIFF
--- a/.deployment
+++ b/.deployment
@@ -1,0 +1,2 @@
+[config]
+project = WebApi/WebApi.csproj

--- a/deploy-manifests/production.yml
+++ b/deploy-manifests/production.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: asset-register-api-production

--- a/deploy-manifests/staging.yml
+++ b/deploy-manifests/staging.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: asset-register-api-staging

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,9 +2,18 @@
 
 set -e
 
+if [ -z "$1" ]; then
+  echo 'Provide an environment to deploy'
+  exit 1
+fi
+
 curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
 ./cf api https://api.cloud.service.gov.uk
-./cf auth "$CF_USER" "$CF_PASSWORD"
-./cf target -o "$CF_ORG" -s "$CF_SPACE"
+./cf auth ${CF_USER} ${CF_PASSWORD}
 
-cd WebApi && ../cf push
+# Use when we can safely deploy to the `staging` and `production` spaces
+# For now, fix to `sandbox` space
+# ./cf target -o ${CF_ORG} -s ${1}
+./cf target -o ${CF_ORG} -s sandbox
+
+./cf push -f deploy-manifests/${1}.yml


### PR DESCRIPTION
Project has been broken down into two components, so this will let CF know which is the main application to deploy, `WebApi` in our case, which will then pull in the required files from `HomesEngland`.

Also updated the deploy script to use separate application manifest files based on environment.

Finally, updated the CF app names to the following format: https://asset-register-api-staging.cloudapps.digital/search which matches their existing app names.