### PR TITLE
Simplify Circle config as build and test scripts no longer required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,19 @@ jobs:
     executor: dotnet
     steps:
       - checkout
-      - run: scripts/build.sh
+      - run: dotnet publish -c Release -o out
 
-  test:
+  test_homes_england:
     executor: dotnet
     steps:
       - checkout
-      - run: scripts/test.sh
+      - run: dotnet test HomesEnglandTest
+
+  test_web_api:
+    executor: dotnet
+    steps:
+      - checkout
+      - run: dotnet test AssetRegisterTest
 
   deploy_staging:
     executor: dotnet
@@ -35,12 +41,16 @@ workflows:
   build_test_deploy:
     jobs:
       - build
-      - test:
+      - test_homes_england:
+          requires:
+            - build
+      - test_web_api:
           requires:
             - build
       - deploy_staging:
           requires:
-            - test
+            - test_homes_england
+            - test_web_api
           filters:
             branches:
               only:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-dotnet publish -c Release -o out

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-dotnet test HomesEnglandTest
-dotnet test AssetRegisterTest


### PR DESCRIPTION
By splitting the tests into two separate jobs, we can simplify the setup by not needing a `build.sh` and `test.sh` script file.