### PR TITLE
Fix target typo and internal listening port no

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   web:
     build: 
       context: .
-      target: webapi-rt
+      target: webapi-runtime
+    environment:
+      - ASPNETCORE_URLS=http://*:5000
     ports:
-    - "5000:80"
+    - "5000:5000"


### PR DESCRIPTION
Extracted `ASPNETCORE_URLS` from original Dockerfile in `WebApi` project.