### PR TITLE
Remove dark staging from deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,29 +52,17 @@ jobs:
       - checkout
       - run: dotnet test InfrastructureTest
 
-  deploy_dark_staging:
+  deploy_staging:
     executor: dotnet
     steps:
       - checkout
-      - run: scripts/deploy-dark.sh staging
-
-  flip_staging:
-    executor: dotnet
-    steps:
-      - checkout
-      - run: scripts/flip-dark-to-live.sh staging
-
-  revert_staging:
-    executor: dotnet
-    steps:
-      - checkout
-      - run: scripts/flip-dark-to-live.sh staging
+      - run: scripts/deploy.sh staging
 
   deploy_dark_production:
     executor: dotnet
     steps:
       - checkout
-      - run: scripts/deploy-dark.sh production
+      - run: scripts/deploy.sh production
 
   flip_production:
     executor: dotnet
@@ -108,7 +96,7 @@ workflows:
       - test_infrastructure:
           requires:
             - build
-      - deploy_dark_staging:
+      - deploy_staging:
           requires:
             - test_homes_england
             - test_web_api
@@ -118,20 +106,10 @@ workflows:
             branches:
               only:
                 - master
-      - flip_staging:
-          requires:
-            - deploy_dark_staging
-      - hold_revert_staging:
-          type: approval
-          requires: 
-            - flip_staging
-      - revert_staging:
-          requires: 
-            - hold_revert_staging
       - hold_production_deploy:
           type: approval
           requires:
-            - flip_staging
+            - deploy_staging
       - deploy_dark_production:
           requires:
             - hold_production_deploy
@@ -147,5 +125,5 @@ workflows:
           requires:
             - flip_production
       - revert_production:
-          requires: 
+          requires:
             - hold_revert_production

--- a/deploy-manifests/production.yml
+++ b/deploy-manifests/production.yml
@@ -1,3 +1,0 @@
----
-applications:
-- name: asset-register-api-production

--- a/deploy-manifests/staging-dark.yml
+++ b/deploy-manifests/staging-dark.yml
@@ -1,6 +1,0 @@
----
-applications:
-- name: asset-register-api-staging-dark
-  memory: 512M
-  services:
-  - asset-register-staging-db

--- a/deploy-manifests/staging.yml
+++ b/deploy-manifests/staging.yml
@@ -1,3 +1,6 @@
 ---
 applications:
 - name: asset-register-api-staging
+  memory: 512M
+  services:
+  - asset-register-staging-db

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,13 +7,18 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+APP_NAME=${1}
+
+if [ "$APP_NAME" == "production" ]; then
+  APP_NAME=${APP_NAME}-dark
+fi
+
 curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
 ./cf api https://api.cloud.service.gov.uk
 ./cf auth ${CF_USER} ${CF_PASSWORD}
 
 ./cf target -o ${CF_ORG} -s ${1}
 
-./cf push -f deploy-manifests/${1}-dark.yml
-./cf set-env asset-register-api-${1}-dark circle_commit ${CIRCLE_SHA1}
-./cf set-env asset-register-api-${1}-dark SENTRY_DSN ${SENTRY_DSN}
-
+./cf push -f deploy-manifests/${APP_NAME}.yml
+./cf set-env asset-register-api-${APP_NAME} circle_commit ${CIRCLE_SHA1}
+./cf set-env asset-register-api-${APP_NAME} SENTRY_DSN ${SENTRY_DSN}


### PR DESCRIPTION
The dark staging environment was used while testing the blue/green deployment setup, but is no longer required. Have removed this from the config, and updated the deploy script to allow for both a standard staging deploy, and a dark production deploy.

Also removed the old `production` PaaS manifest as production is only ever deployed via the dark app and then flipped to live.