### PR TITLE
run docker commands as a normal user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM microsoft/dotnet:2.1.500-sdk AS base
 
 WORKDIR /app
 
+# Set up world readable folders for dotnet + package caching
+# This allows us to run as non-root
+RUN mkdir -m 777 /.dotnet
+RUN mkdir -m 777 /.nuget
+
+
 FROM base as development
 # we don't need to do anything else here, since we'll be using
 # a volume

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 COMPOSE = docker-compose
-RUN_WEB = $(COMPOSE) run --rm web
-RUN_WEB_SERVICE = $(COMPOSE) run --rm --service-ports web
+
+UID ?= $(shell id -u)
+RUN_WEB = $(COMPOSE) run -u $(UID) --rm web
+RUN_WEB_SERVICE = $(COMPOSE) run -u $(UID) --rm --service-ports web
 
 
 .PHONY: \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,9 @@ services:
     volumes:
       - '.:/app'
       # persist the home, as cache goes in it
-      - 'home:/root'
+      - 'nuget:/.nuget'
+      - 'dotnet:/.dotnet'
 
 volumes:
-  home:
+  nuget:
+  dotnet:


### PR DESCRIPTION
Currently, running as root causes issues with generating unreadable dependencies, mainly
due to the way volumes work.

Run commands as a user with the same UID to avoid conflicts of perms