### PR TITLE
Feature/export csv nuget package

### DIFF
--- a/ArchitectureDecisionRecords/1-CsvExport.md
+++ b/ArchitectureDecisionRecords/1-CsvExport.md
@@ -1,7 +1,3 @@
-# ADR template by Michael Nygard
-
-This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
-
 In each ADR file, write these sections:
 
 * **Title**: Idiotmatic way of serializing data into csv format.

--- a/ArchitectureDecisionRecords/1-CsvExport.md
+++ b/ArchitectureDecisionRecords/1-CsvExport.md
@@ -1,17 +1,17 @@
 In each ADR file, write these sections:
 
-* **Title**: Idiotmatic way of serializing data into csv format.
+**Title**: Idiotmatic way of serializing data into csv format.
 
-* **Status**: Accepted
+**Status**: Accepted
 
-* **Context**: The client use case is exporting indivual records as comma separated file (.csv)
+**Context**: The client use case is exporting indivual records as comma separated file (.csv)
 - Option 1: Manually serialize the data to csv and output it via the ```Response.WriteAsync();```
 - Option 2: Create Custom OutputFormatter 
 - Option 3: Use existing nuget package.
 
-* **Decision**: The decision we have gone with is Option 3. Thereby removing the need to have the output model be aware of any sort of serialization, and allowing us quickest and cleanest delivery time of this feature.
+**Decision**: The decision we have gone with is Option 3. Thereby removing the need to have the output model be aware of any sort of serialization, and allowing us quickest and cleanest delivery time of this feature.
 
-* **Consequences**: 
+**Consequences**: 
 - Idiotmatic way of serializing data into csv format.
 - Easily configurable
 - Potentially restrictive around DateTime serialization.

--- a/ArchitectureDecisionRecords/1-CsvExport.md
+++ b/ArchitectureDecisionRecords/1-CsvExport.md
@@ -1,0 +1,21 @@
+# ADR template by Michael Nygard
+
+This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+
+In each ADR file, write these sections:
+
+* **Title**: Idiotmatic way of serializing data into csv format.
+
+* **Status**: Accepted
+
+* **Context**: The client use case is exporting indivual records as comma separated file (.csv)
+
+* **Decision**: The decision we have gone with is to make use of the dotnet core output formatters as a delivery mechanism. Thereby removing the need to have the output model be aware of any sort of serialization. 
+
+* **Consequences**: 
+- Idiotmatic way of serializing data into csv format.
+- Easily configurable
+- Potentially restrictive around DateTime serialization.
+- Allows http requests to response "accept" headers.
+- Complies with RESTful API.
+- Dependent on nuget package - WebApiContrib.Core.Formatter.Csv.

--- a/ArchitectureDecisionRecords/1-CsvExport.md
+++ b/ArchitectureDecisionRecords/1-CsvExport.md
@@ -5,8 +5,11 @@ In each ADR file, write these sections:
 * **Status**: Accepted
 
 * **Context**: The client use case is exporting indivual records as comma separated file (.csv)
+- Option 1: Manually serialize the data to csv and output it via the ```Response.WriteAsync();```
+- Option 2: Create Custom OutputFormatter 
+- Option 3: Use existing nuget package.
 
-* **Decision**: The decision we have gone with is to make use of the dotnet core output formatters as a delivery mechanism. Thereby removing the need to have the output model be aware of any sort of serialization. 
+* **Decision**: The decision we have gone with is Option 3. Thereby removing the need to have the output model be aware of any sort of serialization, and allowing us quickest and cleanest delivery time of this feature.
 
 * **Consequences**: 
 - Idiotmatic way of serializing data into csv format.
@@ -14,4 +17,5 @@ In each ADR file, write these sections:
 - Potentially restrictive around DateTime serialization.
 - Allows http requests to response "accept" headers.
 - Complies with RESTful API.
-- Dependent on nuget package - WebApiContrib.Core.Formatter.Csv.
+- Dependent on nuget package - WebApiContrib.Core.Formatter.Csv
+- We have to do manual testing around this until we have EndToEnd Tests.

--- a/HomesEngland/UseCase/GetAsset/Models/GetAssetResponse.cs
+++ b/HomesEngland/UseCase/GetAsset/Models/GetAssetResponse.cs
@@ -1,7 +1,14 @@
-﻿namespace HomesEngland.UseCase.GetAsset.Models
+﻿using System.Collections.Generic;
+using HomesEngland.UseCase.SearchAsset.Models;
+
+namespace HomesEngland.UseCase.GetAsset.Models
 {
-    public class GetAssetResponse
+    public class GetAssetResponse:IResponse<AssetOutputModel>
     {
         public AssetOutputModel Asset { get; set; }
+        public IList<AssetOutputModel> ToCsv()
+        {
+            return new List<AssetOutputModel>{Asset};
+        }
     }
 }

--- a/HomesEngland/UseCase/SearchAsset/Models/SearchAssetResponse.cs
+++ b/HomesEngland/UseCase/SearchAsset/Models/SearchAssetResponse.cs
@@ -4,10 +4,19 @@ using HomesEngland.UseCase.GetAsset.Models;
 
 namespace HomesEngland.UseCase.SearchAsset.Models
 {
-    public class SearchAssetResponse
+    public class SearchAssetResponse: IResponse<AssetOutputModel>
     {
         public IList<AssetOutputModel> Assets { get; set; }
         public int Pages { get; set; }
         public int TotalCount { get; set; }
+        public IList<AssetOutputModel> ToCsv()
+        {
+            return Assets;
+        }
+    }
+
+    public interface IResponse<T>
+    {
+        IList<T> ToCsv();
     }
 }

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ The application runs on port `5000`.
 [link_gov_pass]: https://www.cloud.service.gov.uk/
 [link_sentry]: https://sentry.io/welcome/
 [link_circleci]: https://circleci.com/
+
+## WebAPI
+
+**CSV Generation**
+
+```WebApiContrib.Core.Formatter.Csv``` library has been used to automatically generate CSV data from an ```IEnumerable<T>``` once the ```accept: text/csv``` header is sent in the request. Please refer to [Csv Outputter](https://github.com/damienbod/WebAPIContrib.Core/tree/master/src/WebApiContrib.Core.Formatter.Csv). Please refer to [architectural decision record 1](./ArchitectureDecisionRecords/1-CsvExport.md).

--- a/WebApi/Controllers/AssetController.cs
+++ b/WebApi/Controllers/AssetController.cs
@@ -22,12 +22,12 @@ namespace WebApi.Controllers
 
         [MapToApiVersion("1")]
         [HttpGet("{id}")]
-        [Produces("application/json")]
+        [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(ApiResponse<GetAssetResponse>), 200)]
         public async Task<IActionResult> Get([FromRoute]GetAssetRequest request)
         {
             var result = await _assetUseCase.ExecuteAsync(request).ConfigureAwait(false);
-            return this.StandardiseResponse(result);
+            return this.StandardiseResponse<GetAssetResponse, AssetOutputModel>(result);
         }
     }
 }

--- a/WebApi/Controllers/Search/SearchAssetController.cs
+++ b/WebApi/Controllers/Search/SearchAssetController.cs
@@ -24,12 +24,12 @@ namespace WebApi.Controllers.Search
 
         [MapToApiVersion("1")]
         [HttpGet("search")]
-        [Produces("application/json")]
+        [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(ApiResponse<SearchAssetResponse>), 200)]
         public async Task<IActionResult> Get([FromQuery]SearchAssetRequest request)
         {
             var result = await _useCase.ExecuteAsync(request, this.GetCancellationToken()).ConfigureAwait(false);
-            return this.StandardiseResponse(result);
+            return this.StandardiseResponse<SearchAssetResponse, AssetOutputModel>(result);
         }
     }
 }

--- a/WebApi/Extensions/ControllerExtensions.cs
+++ b/WebApi/Extensions/ControllerExtensions.cs
@@ -1,15 +1,27 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
+using HomesEngland.UseCase.SearchAsset.Models;
 using Infrastructure.Api.Response;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 
 namespace WebApi.Extensions
 {
     public static class ControllerExtensions
     {
-        public static IActionResult StandardiseResponse<T>(this ControllerBase controller, T useCaseResult)
+        public static IActionResult StandardiseResponse<TResponse,TData>(this ControllerBase controller, TResponse useCaseResult) where TResponse:IResponse<TData>
         {
-            var apiResponse = new ApiResponse<T>(useCaseResult);
-            return controller.StatusCode(apiResponse.StatusCode, apiResponse);
+            controller.HttpContext?.Response?.Headers.Add("Content-Disposition", "attachment; filename=export.csv;");
+            if (controller?.Request != null &&
+                controller.Request.Headers.Contains(new KeyValuePair<string, StringValues>("accept", "text/csv")))
+            {
+                
+                return controller.StatusCode(200, useCaseResult?.ToCsv());
+            }
+                
+            var apiResponse = new ApiResponse<TResponse>(useCaseResult);
+
+            return controller?.StatusCode(apiResponse.StatusCode, apiResponse);
         }
 
         public static CancellationToken GetCancellationToken(this ControllerBase controller)

--- a/WebApi/Extensions/ControllerExtensions.cs
+++ b/WebApi/Extensions/ControllerExtensions.cs
@@ -11,11 +11,11 @@ namespace WebApi.Extensions
     {
         public static IActionResult StandardiseResponse<TResponse,TData>(this ControllerBase controller, TResponse useCaseResult) where TResponse:IResponse<TData>
         {
-            controller.HttpContext?.Response?.Headers.Add("Content-Disposition", "attachment; filename=export.csv;");
+            
             if (controller?.Request != null &&
-                controller.Request.Headers.Contains(new KeyValuePair<string, StringValues>("accept", "text/csv")))
+                controller.ControllerContext.HttpContext.Request.Headers.Contains(new KeyValuePair<string, StringValues>("accept", "text/csv")))
             {
-                
+                controller.ControllerContext.HttpContext?.Response?.Headers.Add("Content-Disposition", "attachment; filename=export.csv;");
                 return controller.StatusCode(200, useCaseResult?.ToCsv());
             }
                 

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -38,13 +38,13 @@ namespace WebApi
                 CsvDelimiter = ",",
                 IncludeExcelDelimiterHeader = true
             };
-            var csvFormatterOptions = new CsvFormatterOptions();
+            
 
             services.AddMvc(options =>
             {
                 options.RespectBrowserAcceptHeader = true;
                 //options.InputFormatters.Add(new CsvInputFormatter(csvFormatterOptions));
-                options.OutputFormatters.Add(new CsvOutputFormatter(csvFormatterOptions));
+                options.OutputFormatters.Add(new CsvOutputFormatter(csvOptions));
                 options.FormatterMappings.SetMediaTypeMappingForFormat("csv", MediaTypeHeaderValue.Parse("text/csv"));
             }).AddCsvSerializerFormatters(csvOptions);
 

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using HomesEngland.Gateway.Migrations;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
+using WebApiContrib.Core.Formatter.Csv;
 
 namespace WebApi
 {
@@ -29,6 +31,22 @@ namespace WebApi
             services.AddCors();
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();
+
+            var csvOptions = new CsvFormatterOptions
+            {
+                UseSingleLineHeaderInCsv = true,
+                CsvDelimiter = ",",
+                IncludeExcelDelimiterHeader = true
+            };
+            var csvFormatterOptions = new CsvFormatterOptions();
+
+            services.AddMvc(options =>
+            {
+                options.RespectBrowserAcceptHeader = true;
+                //options.InputFormatters.Add(new CsvInputFormatter(csvFormatterOptions));
+                options.OutputFormatters.Add(new CsvOutputFormatter(csvFormatterOptions));
+                options.FormatterMappings.SetMediaTypeMappingForFormat("csv", MediaTypeHeaderValue.Parse("text/csv"));
+            }).AddCsvSerializerFormatters(csvOptions);
 
             var assetRegister = new AssetRegister();
             assetRegister.ExportDependencies((type, provider) => services.AddTransient(type, _ => provider()));
@@ -61,6 +79,8 @@ namespace WebApi
 
             app.UseHttpsRedirection();
             app.UseMvc();
+
+            
         }
     }
 }

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -38,7 +38,6 @@ namespace WebApi
                 CsvDelimiter = ",",
                 IncludeExcelDelimiterHeader = true
             };
-            
 
             services.AddMvc(options =>
             {
@@ -79,8 +78,6 @@ namespace WebApi
 
             app.UseHttpsRedirection();
             app.UseMvc();
-
-            
         }
     }
 }

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
     <PackageReference Include="Sentry.AspNetCore" Version="1.0.1-beta" />
+    <PackageReference Include="WebApiContrib.Core.Formatter.Csv" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApiTest/Controller/Asset/Get/AssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Get/AssetControllerTests.cs
@@ -10,11 +10,8 @@ using FluentAssertions;
 using Infrastructure.Api.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Primitives;
 using TestHelper;
-using WebApiContrib.Core.Formatter.Csv;
 
 namespace WebApiTest.Controller.Asset.Get
 {

--- a/WebApiTest/Controller/Asset/Get/AssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Get/AssetControllerTests.cs
@@ -33,7 +33,7 @@ namespace WebApiTest.Controller.Asset.Get
         }
 
         [Test]
-        public async Task GivenInValidRequest_ThenThrowsBadRequestException()
+        public void GivenInValidRequest_ThenThrowsBadRequestException()
         {
             //arrange
             _mockUseCase.Setup(s => s.ExecuteAsync(It.IsAny<GetAssetRequest>())).Throws<BadRequestException>();

--- a/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
@@ -1,11 +1,18 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Bogus;
 using FluentAssertions;
+using HomesEngland.UseCase.GetAsset.Models;
 using HomesEngland.UseCase.SearchAsset;
 using HomesEngland.UseCase.SearchAsset.Models;
 using Infrastructure.Api.Exceptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using NUnit.Framework;
+using TestHelper;
 using WebApi.Controllers.Search;
 
 namespace WebApiTest.Controller.Asset.Search
@@ -31,6 +38,35 @@ namespace WebApiTest.Controller.Asset.Search
             var response = await _classUnderTest.Get(request);
             //assert
             response.Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task GivenValidRequestWithAcceptTextCsvHeader_ThenReturnsListOfAssetOutputModel()
+        {
+            //arrange
+            var assetOutputModel = new AssetOutputModel(TestData.Domain.GenerateAsset());
+            assetOutputModel.Id = Faker.GlobalUniqueIndex;
+            assetOutputModel.SchemeId = Faker.GlobalUniqueIndex;
+            _mockUseCase.Setup(s => s.ExecuteAsync(It.IsAny<SearchAssetRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new SearchAssetResponse
+            {
+                Assets = new List<AssetOutputModel>{ assetOutputModel}
+            });
+            _classUnderTest.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            _classUnderTest.ControllerContext.HttpContext.Request.Headers.Add(new KeyValuePair<string, StringValues>("accept", "text/csv"));
+            var request = new SearchAssetRequest
+            {
+                SchemeId = assetOutputModel.SchemeId
+            };
+            //act
+            var response = await _classUnderTest.Get(request).ConfigureAwait(false);
+            //assert
+            response.Should().NotBeNull();
+            var result = response as ObjectResult;
+            result.Should().NotBeNull();
+            result.Value.Should().BeOfType<List<AssetOutputModel>>();
         }
 
         [Test]

--- a/WebApiTest/WebApiTest.csproj
+++ b/WebApiTest/WebApiTest.csproj
@@ -19,6 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\TestHelper\TestHelper.csproj" />
       <ProjectReference Include="..\WebApi\WebApi.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
What this does:
- Return a List of AssetOutputModels when the accept: text/csv header is present.
- Serialize to CSV format using a nuget package which serializes all fields in order that they appear in the class.
- Prompts to download in the browser.
- Currently filename is simply export.csv
- Correctly opens in Excel by default.
<img width="1427" alt="screen shot 2018-12-05 at 08 53 58" src="https://user-images.githubusercontent.com/5268123/49501680-58372c00-f86b-11e8-9d54-68977a7577a6.png">
- Allows to download CSV serialized list as text.
<img width="1386" alt="screen shot 2018-12-05 at 08 50 45" src="https://user-images.githubusercontent.com/5268123/49501504-ed85f080-f86a-11e8-9e88-6d1fe9bf0343.png">

What this needs to do:
- Add End to End tests to test serialization.

Potential issues:
- Control over formatting of dates.

Potential improvements:
- Set filename to be more contextual.

