### PR TITLE
Add Household Income and EstimatedValuation

### DIFF
--- a/HomesEngland.Gateway/DapperAsset.cs
+++ b/HomesEngland.Gateway/DapperAsset.cs
@@ -147,6 +147,9 @@ namespace HomesEngland.Gateway
         public decimal? ExpectedStaircasingRate { get; set; }
         [Column("estimatedsaleprice")]
         public decimal? EstimatedSalePrice { get; set; }
+        [Column("estimatedvaluation")]
+        public decimal? EstimatedValuation { get; set; }
+
         [Column("regionalsaleadjust")]
         public decimal? RegionalSaleAdjust { get; set; }
         [Column("regionalstairadjust")]
@@ -171,6 +174,9 @@ namespace HomesEngland.Gateway
         public string HouseType { get; set; }
         [Column("purchasepriceband")]
         public decimal? PurchasePriceBand { get; set; }
+        [Column("householdincome")]
+        public decimal? HouseholdIncome { get; set; }
+
         [Column("householdfivekincomeband")]
         public decimal? HouseholdFiveKIncomeBand { get; set; }
         [Column("householdfiftykincomeband")]
@@ -258,6 +264,9 @@ namespace HomesEngland.Gateway
             HouseholdFiveKIncomeBand = request.HouseholdFiveKIncomeBand;
             HouseholdFiftyKIncomeBand = request.HouseholdFiftyKIncomeBand;
             FirstTimeBuyer = request.FirstTimeBuyer;
+
+            HouseholdIncome = request.HouseholdIncome;
+            EstimatedValuation = request.EstimatedValuation;
         }
     }
 }

--- a/HomesEngland.Gateway/Migrations/20181214155118_additional_fields.Designer.cs
+++ b/HomesEngland.Gateway/Migrations/20181214155118_additional_fields.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using HomesEngland.Gateway.Migrations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace HomesEngland.Gateway.Migrations
 {
     [DbContext(typeof(AssetRegisterContext))]
-    partial class AssetRegisterContextModelSnapshot : ModelSnapshot
+    [Migration("20181214155118_additional_fields")]
+    partial class additional_fields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HomesEngland.Gateway/Migrations/20181214155118_additional_fields.cs
+++ b/HomesEngland.Gateway/Migrations/20181214155118_additional_fields.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HomesEngland.Gateway.Migrations
+{
+    public partial class additional_fields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "householdincome",
+                table: "assets", 
+                nullable:true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "estimatedvaluation",
+                table: "assets",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "householdincome",
+                table: "assets");
+
+            migrationBuilder.DropColumn(
+                name: "estimatedvaluation",
+                table: "assets");
+        }
+    }
+}

--- a/HomesEngland/Domain/Asset.cs
+++ b/HomesEngland/Domain/Asset.cs
@@ -72,6 +72,7 @@ namespace HomesEngland.Domain
             Tenure = request.Tenure;
             ExpectedStaircasingRate = request.ExpectedStaircasingRate;
             EstimatedSalePrice = request.EstimatedSalePrice;
+            EstimatedValuation = request.EstimatedValuation;
             RegionalSaleAdjust = request.RegionalSaleAdjust;
             RegionalStairAdjust = request.RegionalStairAdjust;
             NotLimitedByFirstCharge = request.NotLimitedByFirstCharge;
@@ -84,9 +85,13 @@ namespace HomesEngland.Domain
             MortgageProvider = request.MortgageProvider;
             HouseType = request.HouseType;
             PurchasePriceBand = request.PurchasePriceBand;
+            HouseholdIncome = request.HouseholdIncome;
             HouseholdFiveKIncomeBand = request.HouseholdFiveKIncomeBand;
             HouseholdFiftyKIncomeBand = request.HouseholdFiftyKIncomeBand;
             FirstTimeBuyer = request.FirstTimeBuyer;
+
+            HouseholdIncome = request.HouseholdIncome;
+            EstimatedValuation = request.EstimatedValuation;
         }
 
         public Asset(IAsset request)
@@ -167,6 +172,9 @@ namespace HomesEngland.Domain
             HouseholdFiveKIncomeBand = request.HouseholdFiveKIncomeBand;
             HouseholdFiftyKIncomeBand = request.HouseholdFiftyKIncomeBand;
             FirstTimeBuyer = request.FirstTimeBuyer;
+
+            HouseholdIncome = request.HouseholdIncome;
+            EstimatedValuation = request.EstimatedValuation;
         }
 
         public string Programme { get; set; }
@@ -230,6 +238,7 @@ namespace HomesEngland.Domain
         public string Tenure { get; set; }
         public decimal? ExpectedStaircasingRate { get; set; }
         public decimal? EstimatedSalePrice { get; set; }
+        public decimal? EstimatedValuation { get; set; }
         public decimal? RegionalSaleAdjust { get; set; }
         public decimal? RegionalStairAdjust { get; set; }
         public bool? NotLimitedByFirstCharge { get; set; }
@@ -242,6 +251,7 @@ namespace HomesEngland.Domain
         public string MortgageProvider { get; set; }
         public string HouseType { get; set; }
         public decimal? PurchasePriceBand { get; set; }
+        public decimal? HouseholdIncome { get; set; }
         public decimal? HouseholdFiveKIncomeBand { get; set; }
         public decimal? HouseholdFiftyKIncomeBand { get; set; }
         public bool? FirstTimeBuyer { get; set; }

--- a/HomesEngland/Domain/Asset.cs
+++ b/HomesEngland/Domain/Asset.cs
@@ -89,9 +89,6 @@ namespace HomesEngland.Domain
             HouseholdFiveKIncomeBand = request.HouseholdFiveKIncomeBand;
             HouseholdFiftyKIncomeBand = request.HouseholdFiftyKIncomeBand;
             FirstTimeBuyer = request.FirstTimeBuyer;
-
-            HouseholdIncome = request.HouseholdIncome;
-            EstimatedValuation = request.EstimatedValuation;
         }
 
         public Asset(IAsset request)

--- a/HomesEngland/Domain/IAsset.cs
+++ b/HomesEngland/Domain/IAsset.cs
@@ -73,6 +73,7 @@ namespace HomesEngland.Domain
         string Tenure { get; set; }
         decimal? ExpectedStaircasingRate { get; set; }
         decimal? EstimatedSalePrice { get; set; }
+        decimal? EstimatedValuation { get; set; }
         decimal? RegionalSaleAdjust { get; set; }
         decimal? RegionalStairAdjust { get; set; }
         bool? NotLimitedByFirstCharge { get; set; }
@@ -85,8 +86,10 @@ namespace HomesEngland.Domain
         string MortgageProvider { get; set; }
         string HouseType { get; set; }
         decimal? PurchasePriceBand { get; set; }
+        decimal? HouseholdIncome { get; set; }
         decimal? HouseholdFiveKIncomeBand { get; set; }
         decimal? HouseholdFiftyKIncomeBand { get; set; }
         bool? FirstTimeBuyer { get; set; }
+
     }
 }

--- a/HomesEngland/UseCase/CreateAsset/Models/CreateAssetRequest.cs
+++ b/HomesEngland/UseCase/CreateAsset/Models/CreateAssetRequest.cs
@@ -80,6 +80,7 @@ namespace HomesEngland.UseCase.CreateAsset.Models
         public string MortgageProvider { get; set; }
         public string HouseType { get; set; }
         public decimal? PurchasePriceBand { get; set; }
+        public decimal? HouseholdIncome { get; set; }
         public decimal? HouseholdFiveKIncomeBand { get; set; }
         public decimal? HouseholdFiftyKIncomeBand { get; set; }
         public bool? FirstTimeBuyer { get; set; }

--- a/HomesEngland/UseCase/CreateAsset/Models/Factory/AssetFactory.cs
+++ b/HomesEngland/UseCase/CreateAsset/Models/Factory/AssetFactory.cs
@@ -81,7 +81,7 @@ namespace HomesEngland.UseCase.CreateAsset.Models.Factory
             decimal? quarterSpend = fields.ElementAtOrDefault(70).TryParseDecimalNullable();
             decimal? purchasePriceBand = fields.ElementAtOrDefault(73).TryParseDecimalNullable();
             // household income
-
+            decimal? householdIncome = fields.ElementAtOrDefault(74).TryParseDecimalNullable();
             decimal? householdFiveKIncomeBand = fields.ElementAtOrDefault(75).TryParseDecimalNullable();
             decimal? householdFiftyKIncomeBand = fields.ElementAtOrDefault(76).TryParseDecimalNullable();
             bool? firstTimeBuyer = ParseFirstTimeBuyer(fields.ElementAtOrDefault(77));
@@ -162,6 +162,7 @@ namespace HomesEngland.UseCase.CreateAsset.Models.Factory
                 MortgageProvider = fields.ElementAtOrDefault(71),
                 HouseType = fields.ElementAtOrDefault(72),
                 PurchasePriceBand = purchasePriceBand,
+                HouseholdIncome = householdIncome,
                 HouseholdFiveKIncomeBand = householdFiveKIncomeBand,
                 HouseholdFiftyKIncomeBand = householdFiftyKIncomeBand,
                 FirstTimeBuyer = firstTimeBuyer

--- a/HomesEngland/UseCase/CreateAsset/Models/Factory/AssetFactory.cs
+++ b/HomesEngland/UseCase/CreateAsset/Models/Factory/AssetFactory.cs
@@ -34,8 +34,7 @@ namespace HomesEngland.UseCase.CreateAsset.Models.Factory
             decimal? fees = fields.ElementAtOrDefault(26).TryParseDecimalNullable();
             decimal? historicUnallocatedFees = fields.ElementAtOrDefault(27).TryParseDecimalNullable();
 
-            decimal? actualAgencyEquityCostIncludingHomeBuyAgentFee =
-                fields.ElementAtOrDefault(28).TryParseDecimalNullable();
+            decimal? actualAgencyEquityCostIncludingHomeBuyAgentFee = fields.ElementAtOrDefault(28).TryParseDecimalNullable();
             DateTime? fullDisposalDate = fields.ElementAtOrDefault(29).TryParseDateTimeNullable();
             decimal? originalAgencyPercentage = fields.ElementAtOrDefault(30).TryParseDecimalNullable("%");
 

--- a/HomesEngland/UseCase/GetAsset/Models/AssetOutputModel.cs
+++ b/HomesEngland/UseCase/GetAsset/Models/AssetOutputModel.cs
@@ -91,6 +91,9 @@ namespace HomesEngland.UseCase.GetAsset.Models
             HouseholdFiveKIncomeBand = asset.HouseholdFiveKIncomeBand;
             HouseholdFiftyKIncomeBand = asset.HouseholdFiftyKIncomeBand;
             FirstTimeBuyer = asset.FirstTimeBuyer;
+
+            HouseholdIncome = asset.HouseholdIncome;
+            EstimatedValuation = asset.EstimatedValuation;
         }
 
         public string Programme { get; set; }
@@ -154,6 +157,7 @@ namespace HomesEngland.UseCase.GetAsset.Models
         public string Tenure { get; set; }
         public decimal? ExpectedStaircasingRate { get; set; }
         public decimal? EstimatedSalePrice { get; set; }
+        public decimal? EstimatedValuation { get; set; }
         public decimal? RegionalSaleAdjust { get; set; }
         public decimal? RegionalStairAdjust { get; set; }
         public bool? NotLimitedByFirstCharge { get; set; }
@@ -166,6 +170,7 @@ namespace HomesEngland.UseCase.GetAsset.Models
         public string MortgageProvider { get; set; }
         public string HouseType { get; set; }
         public decimal? PurchasePriceBand { get; set; }
+        public decimal? HouseholdIncome { get; set; }
         public decimal? HouseholdFiveKIncomeBand { get; set; }
         public decimal? HouseholdFiftyKIncomeBand { get; set; }
         public bool? FirstTimeBuyer { get; set; }

--- a/HomesEnglandTest/Domain/CreateAssetRequestFactoryTests.cs
+++ b/HomesEnglandTest/Domain/CreateAssetRequestFactoryTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Bogus.DataSets;
 using FluentAssertions;
 using HomesEngland.Domain.Factory;
 using HomesEngland.UseCase.CreateAsset.Models;
 using HomesEngland.UseCase.CreateAsset.Models.Factory;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.Mapping;
 using NUnit.Framework;
 
 namespace HomesEnglandTest.Domain
@@ -134,6 +132,7 @@ namespace HomesEnglandTest.Domain
             asset.MortgageProvider.Should().NotBeNull();
             asset.HouseType.Should().NotBeNull();
             asset.PurchasePriceBand.Should().NotBeNull();
+            asset.HouseholdIncome.Should().NotBeNull();
             asset.HouseholdFiveKIncomeBand.Should().NotBeNull();
             asset.HouseholdFiftyKIncomeBand.Should().NotBeNull();
             asset.FirstTimeBuyer.Should().NotBeNull();
@@ -335,6 +334,7 @@ namespace HomesEnglandTest.Domain
             asset.HouseType.Should().Be("Semi-detached");
             asset.PurchasePriceBand.Should().Be(200000);
             // Household income
+            asset.HouseholdIncome.Should().Be(28842);
             asset.HouseholdFiveKIncomeBand.Should().Be(30000);
             asset.HouseholdFiftyKIncomeBand.Should().Be(50000);
             asset.FirstTimeBuyer.Should().Be(true);

--- a/TestHelper/AssetOutputModelTestHelper.cs
+++ b/TestHelper/AssetOutputModelTestHelper.cs
@@ -91,6 +91,9 @@ namespace TestHelper
             assetOutputModel.HouseholdFiveKIncomeBand.Should().Be(entity.HouseholdFiveKIncomeBand);
             assetOutputModel.HouseholdFiftyKIncomeBand.Should().Be(entity.HouseholdFiftyKIncomeBand);
             assetOutputModel.FirstTimeBuyer.Should().Be(entity.FirstTimeBuyer);
+
+            assetOutputModel.HouseholdIncome.Should().Be(entity.HouseholdIncome);
+            assetOutputModel.EstimatedValuation.Should().Be(entity.EstimatedValuation);
         }
     }
 }

--- a/TestHelper/AssetTestHelper.cs
+++ b/TestHelper/AssetTestHelper.cs
@@ -96,6 +96,9 @@ namespace TestHelper
             readAsset.HouseholdFiveKIncomeBand.Should().Be(entity.HouseholdFiveKIncomeBand);
             readAsset.HouseholdFiftyKIncomeBand.Should().Be(entity.HouseholdFiftyKIncomeBand);
             readAsset.FirstTimeBuyer.Should().Be(entity.FirstTimeBuyer);
+
+            readAsset.HouseholdIncome.Should().Be(entity.HouseholdIncome);
+            readAsset.EstimatedValuation.Should().Be(entity.EstimatedValuation);
         }
 
         /// <summary>
@@ -185,7 +188,10 @@ namespace TestHelper
                 readAsset.PurchasePriceBand.Equals(entity.PurchasePriceBand) &&
                 readAsset.HouseholdFiveKIncomeBand.Equals(entity.HouseholdFiveKIncomeBand) &&
                 readAsset.HouseholdFiftyKIncomeBand.Equals(entity.HouseholdFiftyKIncomeBand) &&
-                readAsset.FirstTimeBuyer.Equals(entity.FirstTimeBuyer);
+                readAsset.FirstTimeBuyer.Equals(entity.FirstTimeBuyer) &&
+
+                readAsset.HouseholdIncome.Equals(entity.HouseholdIncome) &&
+                readAsset.EstimatedValuation.Equals(entity.EstimatedValuation);
         }
 
         /// <summary>
@@ -272,6 +278,9 @@ namespace TestHelper
             readAsset.HouseholdFiveKIncomeBand.Should().Be(entity.HouseholdFiveKIncomeBand);
             readAsset.HouseholdFiftyKIncomeBand.Should().Be(entity.HouseholdFiftyKIncomeBand);
             readAsset.FirstTimeBuyer.Should().Be(entity.FirstTimeBuyer);
+
+            readAsset.HouseholdIncome.Should().Be(entity.HouseholdIncome);
+            readAsset.EstimatedValuation.Should().Be(entity.EstimatedValuation);
         }
 
         /// <summary>
@@ -361,6 +370,9 @@ namespace TestHelper
             readAsset.HouseholdFiveKIncomeBand.Should().Be(entity.HouseholdFiveKIncomeBand);
             readAsset.HouseholdFiftyKIncomeBand.Should().Be(entity.HouseholdFiftyKIncomeBand);
             readAsset.FirstTimeBuyer.Should().Be(entity.FirstTimeBuyer);
+
+            readAsset.HouseholdIncome.Should().Be(entity.HouseholdIncome);
+            readAsset.EstimatedValuation.Should().Be(entity.EstimatedValuation);
         }
     }
 }

--- a/TestHelper/TestData.cs
+++ b/TestHelper/TestData.cs
@@ -46,17 +46,22 @@ namespace TestHelper
                     .RuleFor(property => property.CompletionDateForHpiStart, (fake, model) => completionDateForHpiStart)
                     .RuleFor(property => property.ImsActualCompletionDate, (fake, model) => imsActualCompletionDate)
                     .RuleFor(property => property.ImsExpectedCompletionDate, (fake, model) => imsExpectedCompletionDate)
-                    .RuleFor(property => property.ImsLegalCompletionDate,(fake, model) => fake.Date.Soon(random.Next(15, 90)))
+                    .RuleFor(property => property.ImsLegalCompletionDate,
+                        (fake, model) => fake.Date.Soon(random.Next(15, 90)))
                     .RuleFor(property => property.HopCompletionDate, (fake, model) => hopCompletionDate)
-                    .RuleFor(property => property.AgencyEquityLoan,(fake, model) => fake.Finance.Amount(5000m, 100000m))
-                    .RuleFor(property => property.DeveloperEquityLoan,(fake, model) => fake.Finance.Amount(5000m, 100000m))
-                    .RuleFor(property => property.ShareOfRestrictedEquity,(fake, model) => fake.Finance.Amount(50, 100))
+                    .RuleFor(property => property.AgencyEquityLoan,
+                        (fake, model) => fake.Finance.Amount(5000m, 100000m))
+                    .RuleFor(property => property.DeveloperEquityLoan,
+                        (fake, model) => fake.Finance.Amount(5000m, 100000m))
+                    .RuleFor(property => property.ShareOfRestrictedEquity,
+                        (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.DeveloperDiscount, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.Mortgage, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.PurchasePrice, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.Fees, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.HistoricUnallocatedFees, (fake, model) => fake.Finance.Amount(50, 100))
-                    .RuleFor(asset => asset.ActualAgencyEquityCostIncludingHomeBuyAgentFee,(fake, model) => fake.Finance.Amount(50, 100))
+                    .RuleFor(asset => asset.ActualAgencyEquityCostIncludingHomeBuyAgentFee,
+                        (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.FullDisposalDate, (fake, model) => fake.Date.Soon(random.Next(15, 90)))
                     .RuleFor(asset => asset.OriginalAgencyPercentage, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.StaircasingPercentage, (fake, model) => fake.Finance.Amount(50, 100))
@@ -80,7 +85,8 @@ namespace TestHelper
                     .RuleFor(asset => asset.AgencyFairValue, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.DisposalsCost, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.DurationInMonths, (fake, model) => fake.Random.Int(1, 12))
-                    .RuleFor(asset => asset.MonthOfCompletionSinceSchemeStart,(fake, model) => fake.Finance.Amount(50, 100))
+                    .RuleFor(asset => asset.MonthOfCompletionSinceSchemeStart,
+                        (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.DisposalMonthSinceCompletion, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.IMSPaymentDate, (fake, model) => fake.Date.Soon(1, DateTime.Now))
                     .RuleFor(asset => asset.IsPaid, (fake, model) => fake.Random.Bool())
@@ -93,9 +99,12 @@ namespace TestHelper
                     .RuleFor(asset => asset.RegionalStairAdjust, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.NotLimitedByFirstCharge, (fake, model) => fake.Random.Bool())
                     .RuleFor(asset => asset.EarlyMortgageIfNeverRepay, (fake, model) => fake.Finance.Amount(50, 100))
-                    .RuleFor(asset => asset.ArrearsEffectAppliedOrLimited,(fake, model) => fake.PickRandom(appliedOrLimited))
-                    .RuleFor(asset => asset.RelativeSalePropertyTypeAndTenureAdjustment,(fake, model) => fake.Finance.Amount(50, 100))
-                    .RuleFor(asset => asset.RelativeStairPropertyTypeAndTenureAdjustment,(fake, model) => fake.Finance.Amount(50, 100))
+                    .RuleFor(asset => asset.ArrearsEffectAppliedOrLimited,
+                        (fake, model) => fake.PickRandom(appliedOrLimited))
+                    .RuleFor(asset => asset.RelativeSalePropertyTypeAndTenureAdjustment,
+                        (fake, model) => fake.Finance.Amount(50, 100))
+                    .RuleFor(asset => asset.RelativeStairPropertyTypeAndTenureAdjustment,
+                        (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.IsLondon, (fake, model) => fake.Random.Bool())
                     .RuleFor(asset => asset.QuarterSpend, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.MortgageProvider, (fake, model) => fake.Company.CompanyName())
@@ -103,7 +112,10 @@ namespace TestHelper
                     .RuleFor(asset => asset.PurchasePriceBand, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.HouseholdFiveKIncomeBand, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.HouseholdFiftyKIncomeBand, (fake, model) => fake.Finance.Amount(50, 100))
-                    .RuleFor(asset => asset.FirstTimeBuyer, (fake, model) => fake.Random.Bool());
+                    .RuleFor(asset => asset.FirstTimeBuyer, (fake, model) => fake.Random.Bool())
+
+                    .RuleFor(asset => asset.HouseholdIncome, (fake, model) => fake.Finance.Amount(25000m, 100000m))
+                    .RuleFor(asset => asset.EstimatedValuation, (fake, model) => fake.Finance.Amount(100000m, 300000m));
 
                 return generatedAsset;
             }
@@ -204,7 +216,10 @@ namespace TestHelper
                     .RuleFor(asset => asset.PurchasePriceBand, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.HouseholdFiveKIncomeBand, (fake, model) => fake.Finance.Amount(50, 100))
                     .RuleFor(asset => asset.HouseholdFiftyKIncomeBand, (fake, model) => fake.Finance.Amount(50, 100))
-                    .RuleFor(asset => asset.FirstTimeBuyer, (fake, model) => fake.Random.Bool());
+                    .RuleFor(asset => asset.FirstTimeBuyer, (fake, model) => fake.Random.Bool())
+
+                    .RuleFor(asset => asset.HouseholdIncome, (fake, model) => fake.Finance.Amount(25000m, 100000m))
+                    .RuleFor(asset => asset.EstimatedValuation, (fake, model) => fake.Finance.Amount(100000m, 300000m));
 
                 return generatedAsset;
             }


### PR DESCRIPTION
What this PR does:
- Add EstimatedValuation and HouseholdIncome to IAsset and mapped models.
- Add Database Migration to add fields to table
- Add EstimatedValuation and HouseholdIncome to Test Data Generation.
- Add Fields to test helper method to check they are parsed and mapped correctly

Notes:
- I deleted a migration that was initially used to add the fields to the AssetRegisterContext and had to re-add them when I deleted and re-created the migration, which thought the fields already existed. 