### PR TITLE
Remove API versioning and Swagger documentation of API versions

### DIFF
--- a/AcceptanceTest/HomesEngland/ConsoleImporter/ConsoleImporterAcceptanceTests.cs
+++ b/AcceptanceTest/HomesEngland/ConsoleImporter/ConsoleImporterAcceptanceTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
+﻿using System.IO;
 using System.Threading.Tasks;
 using System.Transactions;
 using FluentAssertions;

--- a/Infrastructure/Documentation/SwaggerApiDocumentation.cs
+++ b/Infrastructure/Documentation/SwaggerApiDocumentation.cs
@@ -22,7 +22,7 @@ namespace Infrastructure.Documentation
         {
             services.AddSwaggerGen(c =>
             {
-                var version = $"v{1}";
+                var version = "v1";
                 c.SwaggerDoc(version, new Info { Title = $"{apiName} {version}", Version = version });
 
                 c.CustomSchemaIds(x => x.FullName);

--- a/Infrastructure/Documentation/SwaggerApiDocumentation.cs
+++ b/Infrastructure/Documentation/SwaggerApiDocumentation.cs
@@ -3,11 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Infrastructure.Versioning;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -17,7 +14,7 @@ namespace Infrastructure.Documentation
     public static class SwaggerApiDocumentation
     {
         /// <summary>
-        /// Pre-Requisite Controllers must [ApiVersion("x")] on them
+        /// 
         /// </summary>
         /// <param name="services"></param>
         /// <param name="apiName"></param>
@@ -25,26 +22,13 @@ namespace Infrastructure.Documentation
         {
             services.AddSwaggerGen(c =>
             {
-                //include the relevant controller version in the relevant versions of the documentation
-                SeperatePerApiVersion(c);
-
-                var apiVersions = services.BuildServiceProvider().GetApiVersionDescriptions();
-
-                GenerateSwaggerVersionPerApiVersion(apiName, apiVersions, c);
+                var version = $"v{1}";
+                c.SwaggerDoc(version, new Info { Title = $"{apiName} {version}", Version = version });
 
                 c.CustomSchemaIds(x => x.FullName);
-                
+
                 IncludeXmlCommentsIfPresent(c);
             });
-        }
-
-        private static void GenerateSwaggerVersionPerApiVersion(string apiName, List<ApiVersionDescription> apiVersions, SwaggerGenOptions c)
-        {
-            foreach (var apiVersion in apiVersions)
-            {
-                var version = $"v{apiVersion.ApiVersion.ToString()}";
-                c.SwaggerDoc(version, new Info {Title = $"{apiName} {version}", Version = version});
-            }
         }
 
         private static void IncludeXmlCommentsIfPresent(SwaggerGenOptions c)
@@ -55,64 +39,25 @@ namespace Infrastructure.Documentation
                 c.IncludeXmlComments(xmlPath);
         }
 
-        private static void SeperatePerApiVersion(SwaggerGenOptions c)
-        {
-            c.DocInclusionPredicate((docName, apiDesc) =>
-            {
-                var versions = apiDesc.ControllerAttributes()
-                    .OfType<ApiVersionAttribute>()
-                    .SelectMany(attr => attr.Versions).ToList();
-
-                var any = versions.Any(v => $"{v.GetFormattedApiVersion()}" == docName);
-                return any;
-            });
-        }
-
         /// <summary>
         /// Pre-Requisite Controllers must [ApiVersion("x")] on them
         /// </summary>
         /// <param name="app"></param>
         /// <param name="apiName"></param>
         /// <returns></returns>
-        public static List<ApiVersionDescription> ConfigureSwaggerUiPerApiVersion(this IApplicationBuilder app, string apiName)
+        public static List<ApiVersionDescription> ConfigureSwaggerUi(this IApplicationBuilder app, string apiName)
         {
-            var api = app.ApplicationServices.GetService<IApiVersionDescriptionProvider>(); 
+            var api = app.ApplicationServices.GetService<IApiVersionDescriptionProvider>();
             var apiVersions = api.ApiVersionDescriptions.Select(s => s).ToList();
             app.UseSwaggerUI(c =>
             {
-                //Generate swagger docs per api version
-                foreach (var apiVersionDescription in apiVersions)
-                {
-                    //Create a swagger endpoint for each swagger version
-                    c.SwaggerEndpoint($"{apiVersionDescription.GetFormattedApiVersion()}/swagger.json",
-                        $"{apiName} {apiVersionDescription.GetFormattedApiVersion()}");
-                }
+                //Create a swagger endpoint for each swagger version
+                c.SwaggerEndpoint($"v{1}/swagger.json", $"{apiName} {1}");
             });
 
             app.UseSwagger();
 
             return apiVersions;
-        }
-    }
-
-    public static class ApiVersioningConfigurationExtension
-    {
-        public static List<ApiVersionDescription> GetApiVersionDescriptions(this IServiceProvider serviceProvider)
-        {
-            var api = serviceProvider.GetService<IApiVersionDescriptionProvider>();
-            var apiVersions = api.ApiVersionDescriptions.Select(s => s).ToList();
-            return apiVersions;
-        }
-
-        public static void ConfigureApiVersioning(this IServiceCollection services)
-        {
-            services.AddApiVersioning(o =>
-            {
-                o.DefaultApiVersion = new ApiVersion(1, 0);
-                o.AssumeDefaultVersionWhenUnspecified = true;
-                // {host}/api/v{apiVersion}/{controller}/*
-                o.ApiVersionReader = new UrlSegmentApiVersionReader();
-            });
         }
     }
 }

--- a/Infrastructure/Documentation/SwaggerApiDocumentation.cs
+++ b/Infrastructure/Documentation/SwaggerApiDocumentation.cs
@@ -52,7 +52,7 @@ namespace Infrastructure.Documentation
             app.UseSwaggerUI(c =>
             {
                 //Create a swagger endpoint for each swagger version
-                c.SwaggerEndpoint($"v{1}/swagger.json", $"{apiName} {1}");
+                c.SwaggerEndpoint($"v1/swagger.json", $"{apiName} 1");
             });
 
             app.UseSwagger();

--- a/WebApi/Controllers/AssetController.cs
+++ b/WebApi/Controllers/AssetController.cs
@@ -7,8 +7,7 @@ using WebApi.Extensions;
 
 namespace WebApi.Controllers
 {
-    [ApiVersion("1")]
-    [Route("api/v{version:ApiVersion}/[controller]")]
+    [Route("api/v1/[controller]")]
     [ApiController]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
     [ProducesResponseType(typeof(ApiResponse<object>), 500)]
@@ -20,7 +19,6 @@ namespace WebApi.Controllers
             _assetUseCase = useCase;
         }
 
-        [MapToApiVersion("1")]
         [HttpGet("{id}")]
         [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(ApiResponse<GetAssetResponse>), 200)]

--- a/WebApi/Controllers/Search/Calculations/CalculationsController.cs
+++ b/WebApi/Controllers/Search/Calculations/CalculationsController.cs
@@ -7,8 +7,8 @@ using WebApi.Extensions;
 
 namespace WebApi.Controllers.Search.Calculations
 {
-    [ApiVersion("1")]
-    [Route("api/v{version:ApiVersion}/asset/search")]
+    
+    [Route("api/v1/asset/search")]
     [ApiController]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
     [ProducesResponseType(typeof(ApiResponse<object>), 500)]
@@ -20,7 +20,6 @@ namespace WebApi.Controllers.Search.Calculations
             _useCase = useCase;
         }
 
-        [MapToApiVersion("1")]
         [HttpGet("aggregation")]
         [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(ApiResponse<CalculateAssetAggregateResponse>), 200)]

--- a/WebApi/Controllers/Search/SearchAssetController.cs
+++ b/WebApi/Controllers/Search/SearchAssetController.cs
@@ -9,8 +9,7 @@ using WebApi.Extensions;
 
 namespace WebApi.Controllers.Search
 {
-    [ApiVersion("1")]
-    [Route("api/v{version:ApiVersion}/asset")]
+    [Route("api/v1/asset")]
     [ApiController]
     [ProducesResponseType(typeof(ApiResponse<object>), 400)]
     [ProducesResponseType(typeof(ApiResponse<object>), 500)]
@@ -22,7 +21,6 @@ namespace WebApi.Controllers.Search
             _useCase = useCase;
         }
 
-        [MapToApiVersion("1")]
         [HttpGet("search")]
         [Produces("application/json", "text/csv")]
         [ProducesResponseType(typeof(ApiResponse<SearchAssetResponse>), 200)]

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -52,7 +52,6 @@ namespace WebApi
 
             assetRegister.ExportTypeDependencies((type, provider) => services.AddTransient(type, provider));
 
-            services.ConfigureApiVersioning();
             services.ConfigureDocumentation(_apiName);
 
             services
@@ -71,7 +70,7 @@ namespace WebApi
             else
                 app.UseHsts();
 
-            app.ConfigureSwaggerUiPerApiVersion(_apiName);
+            app.ConfigureSwaggerUi(_apiName);
             app.UseCors(builder =>
                 builder.WithOrigins(configuration["CorsOrigins"].Split(";"))
                        .AllowAnyHeader()


### PR DESCRIPTION
What changes were made:
- Remove API versioning
- Remove Swagger Documentation per version
- Retain manual v1 versioning.

Why these changes were made:
- Conform to [API standards](https://github.com/homes-england/api-standards/blob/master/standards/compatibility.md)