### PR TITLE
Create use case for authenticating user with dummy gateways

### DIFF
--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.5.3" />
+        <PackageReference Include="FluentSimulator" Version="1.0.33" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="Moq" Version="4.10.0" />

--- a/AcceptanceTest/HomesEngland/UseCases/AuthenticationTests.cs
+++ b/AcceptanceTest/HomesEngland/UseCases/AuthenticationTests.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using FluentAssertions;
+using FluentSim;
+using HomesEngland.UseCase.AuthenticateUser;
+using HomesEngland.UseCase.AuthenticateUser.Models;
+using Main;
+using NUnit.Framework;
+
+namespace AssetRegisterTests.HomesEngland.UseCases
+{
+    [TestFixture]
+    public class AuthenticationTests
+    {
+        private readonly IAuthenticateUser _authenticateUser;
+
+        public AuthenticationTests()
+        {
+            var assetRegister = new AssetRegister();
+            _authenticateUser = assetRegister.Get<IAuthenticateUser>();
+        }
+
+        private TransactionScope ATransaction()
+        {
+            return new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        }
+
+        private class NotifyRequest
+        {
+        }
+
+        [Test]
+        [Ignore("Notification gateway not yet implemented")]
+        public async Task GivenUserIsAuthorised_SendAnEmailContainingATokenToTheUser()
+        {
+            System.Environment.SetEnvironmentVariable("GOV_NOTIFY_URL", "http://meow.cat:7654/");
+            System.Environment.SetEnvironmentVariable("EMAIL_WHITELIST", "test@example.com");
+            using (ATransaction())
+            {
+                var simulator = new FluentSimulator("http://meow.cat:7654/");
+                simulator.Post("/v2/notifications/email").Responds().WithCode(200);
+
+                AuthenticateUserRequest request = new AuthenticateUserRequest
+                {
+                    Email = "test@example.com"
+                };
+
+                await _authenticateUser.ExecuteAsync(request, CancellationToken.None);
+
+                var notifyRequest = simulator.ReceivedRequests[0].BodyAs<NotifyRequest>();
+
+                notifyRequest.Should().NotBeNull();
+            }
+        }
+    }
+}

--- a/HomesEngland.Gateway/HomesEngland.Gateway.csproj
+++ b/HomesEngland.Gateway/HomesEngland.Gateway.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
   <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>

--- a/HomesEngland.Gateway/Sql/DummyNotificationGateway.cs
+++ b/HomesEngland.Gateway/Sql/DummyNotificationGateway.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.Notifications;
+
+namespace HomesEngland.Gateway.Sql
+{
+    public class DummyNotificationGateway : IOneTimeLinkNotifier
+    {
+        public Task<bool> SendOneTimeLinkAsync(IOneTimeLinkNotification notification)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/HomesEngland.Gateway/Sql/DummySqlAuthenticationTokenGateway.cs
+++ b/HomesEngland.Gateway/Sql/DummySqlAuthenticationTokenGateway.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AuthenticationTokens;
+
+namespace HomesEngland.Gateway.Sql
+{
+    public class DummySqlAuthenticationTokenGateway : IOneTimeAuthenticationTokenCreator
+    {
+        public async Task<IAuthenticationToken> CreateAsync(IAuthenticationToken token)
+        {
+            return new AuthenticationToken
+            {
+                Email = "test@test.com",
+                Token = "dummy"
+            };
+        }
+    }
+}

--- a/HomesEngland/Domain/AuthenticationToken.cs
+++ b/HomesEngland/Domain/AuthenticationToken.cs
@@ -1,0 +1,8 @@
+namespace HomesEngland.Domain
+{
+    public class AuthenticationToken : IAuthenticationToken
+    {
+        public string Email { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/HomesEngland/Domain/IAuthenticationToken.cs
+++ b/HomesEngland/Domain/IAuthenticationToken.cs
@@ -1,0 +1,8 @@
+namespace HomesEngland.Domain
+{
+    public interface IAuthenticationToken
+    {
+        string Email { get; }
+        string Token { get; }
+    }
+}

--- a/HomesEngland/Domain/IOneTimeLinkNotification.cs
+++ b/HomesEngland/Domain/IOneTimeLinkNotification.cs
@@ -1,0 +1,8 @@
+namespace HomesEngland.Domain
+{
+    public interface IOneTimeLinkNotification
+    {
+        string Email { get; set; }
+        string Token { get; set; }
+    }
+}

--- a/HomesEngland/Domain/OneTimeLinkNotification.cs
+++ b/HomesEngland/Domain/OneTimeLinkNotification.cs
@@ -1,0 +1,8 @@
+namespace HomesEngland.Domain
+{
+    public class OneTimeLinkNotification : IOneTimeLinkNotification
+    {
+        public string Email { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/HomesEngland/Gateway/AuthenticationTokens/IOneTimeAuthenticationTokenCreator.cs
+++ b/HomesEngland/Gateway/AuthenticationTokens/IOneTimeAuthenticationTokenCreator.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+
+namespace HomesEngland.Gateway.AuthenticationTokens
+{
+    public interface IOneTimeAuthenticationTokenCreator
+    {
+        Task<IAuthenticationToken> CreateAsync(IAuthenticationToken token);
+    }
+}

--- a/HomesEngland/Gateway/Notifications/IOneTimeLinkNotifier.cs
+++ b/HomesEngland/Gateway/Notifications/IOneTimeLinkNotifier.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+
+namespace HomesEngland.Gateway.Notifications
+{
+    public interface IOneTimeLinkNotifier
+    {
+        Task<bool> SendOneTimeLinkAsync(IOneTimeLinkNotification notification);
+    }
+}

--- a/HomesEngland/UseCase/AuthenticateUser/IAuthenticateUser.cs
+++ b/HomesEngland/UseCase/AuthenticateUser/IAuthenticateUser.cs
@@ -1,0 +1,9 @@
+using HomesEngland.Boundary.UseCase;
+using HomesEngland.UseCase.AuthenticateUser.Models;
+
+namespace HomesEngland.UseCase.AuthenticateUser
+{
+    public interface IAuthenticateUser : IAsyncUseCaseTask<AuthenticateUserRequest, AuthenticateUserResponse>
+    {
+    }
+}

--- a/HomesEngland/UseCase/AuthenticateUser/Impl/AuthenticateUserUseCase.cs
+++ b/HomesEngland/UseCase/AuthenticateUser/Impl/AuthenticateUserUseCase.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AuthenticationTokens;
+using HomesEngland.Gateway.Notifications;
+using HomesEngland.UseCase.AuthenticateUser.Models;
+
+namespace HomesEngland.UseCase.AuthenticateUser.Impl
+{
+    public class AuthenticateUserUseCase : IAuthenticateUser
+    {
+        private IOneTimeAuthenticationTokenCreator _authenticationTokenCreator;
+        private IOneTimeLinkNotifier _oneTimeLinkNotifier;
+
+        public AuthenticateUserUseCase(IOneTimeAuthenticationTokenCreator authenticationTokenCreator,
+            IOneTimeLinkNotifier notifier)
+        {
+            _authenticationTokenCreator = authenticationTokenCreator;
+            _oneTimeLinkNotifier = notifier;
+        }
+
+        public async Task<AuthenticateUserResponse> ExecuteAsync(AuthenticateUserRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!UserIsAuthorised(request.Email))
+            {
+                return UnauthorisedResponse();
+            }
+
+            IAuthenticationToken token = new AuthenticationToken
+            {
+                Email = request.Email
+            };
+
+            IAuthenticationToken createdToken = await _authenticationTokenCreator.CreateAsync(token);
+
+            await _oneTimeLinkNotifier.SendOneTimeLinkAsync(new OneTimeLinkNotification
+            {
+                Email = createdToken.Email,
+                Token = createdToken.Token
+            });
+
+            return new AuthenticateUserResponse
+            {
+                Authorised = true
+            };
+        }
+
+        private AuthenticateUserResponse UnauthorisedResponse()
+        {
+            return new AuthenticateUserResponse
+            {
+                Authorised = false
+            };
+        }
+
+        private bool UserIsAuthorised(string email)
+        {
+            var whitelist = System.Environment.GetEnvironmentVariable("EMAIL_WHITELIST").Split(";").ToList();
+            return whitelist.Contains(email);
+        }
+    }
+}

--- a/HomesEngland/UseCase/AuthenticateUser/Models/AuthenticateUserRequest.cs
+++ b/HomesEngland/UseCase/AuthenticateUser/Models/AuthenticateUserRequest.cs
@@ -1,0 +1,7 @@
+namespace HomesEngland.UseCase.AuthenticateUser.Models
+{
+    public class AuthenticateUserRequest
+    {
+        public string Email { get; set; }
+    }
+}

--- a/HomesEngland/UseCase/AuthenticateUser/Models/AuthenticateUserResponse.cs
+++ b/HomesEngland/UseCase/AuthenticateUser/Models/AuthenticateUserResponse.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace HomesEngland.UseCase.AuthenticateUser.Models
+{
+    public class AuthenticateUserResponse
+    {
+        public bool Authorised { get; set; }
+    }
+}

--- a/HomesEnglandTest/UseCase/AuthenticateUser/AuthenticateUserTests.cs
+++ b/HomesEnglandTest/UseCase/AuthenticateUser/AuthenticateUserTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AuthenticationTokens;
+using HomesEngland.Gateway.Notifications;
+using HomesEngland.UseCase.AuthenticateUser;
+using HomesEngland.UseCase.AuthenticateUser.Impl;
+using HomesEngland.UseCase.AuthenticateUser.Models;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace HomesEnglandTest.UseCase.AuthenticateUser
+{
+    public class AuthenticateUserTests
+    {
+        private static IAuthenticateUser _classUnderTest;
+        private static IOneTimeAuthenticationTokenCreator _tokenCreatorSpy;
+        private static IOneTimeLinkNotifier _notifierSpy;
+
+        private string _authorisedEmails;
+
+        public AuthenticateUserTests()
+        {
+            _tokenCreatorSpy = Substitute.For<IOneTimeAuthenticationTokenCreator>();
+            _notifierSpy = Substitute.For<IOneTimeLinkNotifier>();
+            _classUnderTest = new AuthenticateUserUseCase(_tokenCreatorSpy, _notifierSpy);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _authorisedEmails = Environment.GetEnvironmentVariable("EMAIL_WHITELISTS");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable("EMAIL_WHITELIST", _authorisedEmails);
+        }
+
+        private static void SetEmailWhitelist(string validEmail)
+        {
+            Environment.SetEnvironmentVariable("EMAIL_WHITELIST", validEmail);
+        }
+
+        private static AuthenticateUserRequest CreateUseCaseRequestForEmail(string invalidEmail)
+        {
+            return new AuthenticateUserRequest
+            {
+                Email = invalidEmail
+            };
+        }
+
+        private static async Task ExpectNotifierGatewayToHaveReceived(string validEmail, string createdTokenString)
+        {
+            await _notifierSpy.Received()
+                .SendOneTimeLinkAsync(Arg.Is<IOneTimeLinkNotification>(req =>
+                    req.Email == validEmail && req.Token == createdTokenString));
+        }
+
+        private class GivenEmailAddressIsNotAllowed : AuthenticateUserTests
+        {
+            private class GivenSingleEmailInWhitelist : GivenEmailAddressIsNotAllowed
+            {
+                [TestCase("test@test.com")]
+                [TestCase("meow@cat.com")]
+                public async Task ItDoesNotCallTheTokenCreatorGateway(string invalidEmail)
+                {
+                    SetEmailWhitelist($"mark-as-invalid-{invalidEmail}");
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(invalidEmail);
+
+                    await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    await _tokenCreatorSpy.DidNotReceive()
+                        .CreateAsync(Arg.Is<IAuthenticationToken>(req => req.Email == invalidEmail));
+                }
+
+                [TestCase("test@test.com")]
+                [TestCase("meow@cat.com")]
+                public async Task ItMarksTheResponseAsUnauthorised(string invalidEmail)
+                {
+                    SetEmailWhitelist($"mark-as-invalid-{invalidEmail}");
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(invalidEmail);
+
+                    AuthenticateUserResponse response =
+                        await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    response.Authorised.Should().BeFalse();
+                }
+            }
+        }
+
+        private class GivenEmailAddressIsAllowed : AuthenticateUserTests
+        {
+            private class GivenSingleEmailInWhitelist : GivenEmailAddressIsAllowed
+            {
+                [TestCase("test@test.com")]
+                [TestCase("cat@meow.com")]
+                public async Task ItCallsTheTokenCreatorGateway(string validEmail)
+                {
+                    SetEmailWhitelist(validEmail);
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    await _tokenCreatorSpy.Received()
+                        .CreateAsync(Arg.Is<IAuthenticationToken>(req => req.Email == validEmail));
+                }
+
+                [TestCase("test@test.com", "token123")]
+                [TestCase("cat@meow.com", "anotherToken456")]
+                public async Task ItPassesTheEmailAndTokenCreatedToTheNotifierGateway(string validEmail,
+                    string createdTokenString)
+                {
+                    SetEmailWhitelist(validEmail);
+                    IAuthenticationToken createdToken = new AuthenticationToken
+                    {
+                        Email = validEmail,
+                        Token = createdTokenString
+                    };
+
+                    _tokenCreatorSpy.CreateAsync(Arg.Any<IAuthenticationToken>()).Returns(createdToken);
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+                    await ExpectNotifierGatewayToHaveReceived(validEmail, createdTokenString);
+                }
+
+                [TestCase("test@test.com")]
+                [TestCase("cat@meow.com")]
+                public async Task ItMarksTheResponseAsAuthorised(string validEmail)
+                {
+                    SetEmailWhitelist(validEmail);
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    AuthenticateUserResponse response =
+                        await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    response.Authorised.Should().BeTrue();
+                }
+            }
+
+            private class GivenMultipleEmailsInWhitelist : GivenEmailAddressIsAllowed
+            {
+                [TestCase("cow@moo.com")]
+                [TestCase("test@example.com")]
+                public async Task ItCallsTheTokenCreatorGateway(string validEmail)
+                {
+                    SetEmailWhitelist($"dog@woof.com;{validEmail};duck@quack.com");
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    await _tokenCreatorSpy.Received()
+                        .CreateAsync(Arg.Is<IAuthenticationToken>(req => req.Email == validEmail));
+                }
+
+                [TestCase("test@test.com", "token123")]
+                [TestCase("cat@meow.com", "anotherToken456")]
+                public async Task ItPassesTheEmailAndTokenCreatedToTheNotifierGateway(string validEmail,
+                    string createdTokenString)
+                {
+                    SetEmailWhitelist($"dog@woof.com;{validEmail};duck@quack.com");
+                    IAuthenticationToken createdToken = new AuthenticationToken
+                    {
+                        Email = validEmail,
+                        Token = createdTokenString
+                    };
+
+                    _tokenCreatorSpy.CreateAsync(Arg.Any<IAuthenticationToken>()).Returns(createdToken);
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+                    await ExpectNotifierGatewayToHaveReceived(validEmail, createdTokenString);
+                }
+
+                [TestCase("test@test.com")]
+                [TestCase("cat@meow.com")]
+                public async Task ItMarksTheResponseAsAuthorised(string validEmail)
+                {
+                    SetEmailWhitelist($"dog@woof.com;{validEmail};duck@quack.com");
+                    AuthenticateUserRequest request = CreateUseCaseRequestForEmail(validEmail);
+
+                    AuthenticateUserResponse response =
+                        await _classUnderTest.ExecuteAsync(request, CancellationToken.None);
+
+                    response.Authorised.Should().BeTrue();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
What does this PR do:
- Adds in the authenticate user use case
- Adds in the interfaces for the token creation & notification gateways
- Adds an acceptance test (currently skipped due to being fully implemented)