### PR TITLE
Feature/asset register versions default versions

### DIFF
--- a/WebApi/Controllers/Search/Calculations/CalculationsController.cs
+++ b/WebApi/Controllers/Search/Calculations/CalculationsController.cs
@@ -40,7 +40,9 @@ namespace WebApi.Controllers.Search.Calculations
         {
             int? assetRegisterVersionId = null;
             if (request.AssetRegisterVersionId.HasValue)
+            {
                 assetRegisterVersionId = request.AssetRegisterVersionId;
+            }
             else
             {
                 var latestAssetRegister = await _assetRegisterVersionSearcher.Search(new PagedQuery

--- a/WebApi/Controllers/Search/Calculations/CalculationsController.cs
+++ b/WebApi/Controllers/Search/Calculations/CalculationsController.cs
@@ -1,8 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.UseCase.CalculateAssetAggregates;
 using HomesEngland.UseCase.CalculateAssetAggregates.Models;
 using Microsoft.AspNetCore.Mvc;
 using WebApi.Extensions;
+using WebApi.Extensions.Requests;
 
 namespace WebApi.Controllers.Search.Calculations
 {
@@ -12,9 +17,12 @@ namespace WebApi.Controllers.Search.Calculations
     public class CalculateAssetAggregatesController : ControllerBase
     {
         private readonly ICalculateAssetAggregatesUseCase _useCase;
-        public CalculateAssetAggregatesController(ICalculateAssetAggregatesUseCase useCase)
+        private readonly IAssetRegisterVersionSearcher _assetRegisterVersionSearcher;
+
+        public CalculateAssetAggregatesController(ICalculateAssetAggregatesUseCase useCase, IAssetRegisterVersionSearcher assetRegisterVersionSearcher)
         {
             _useCase = useCase;
+            _assetRegisterVersionSearcher = assetRegisterVersionSearcher;
         }
 
         [HttpGet("aggregation")]
@@ -22,8 +30,28 @@ namespace WebApi.Controllers.Search.Calculations
         [ProducesResponseType(typeof(ResponseData<CalculateAssetAggregateResponse>), 200)]
         public async Task<IActionResult> Get([FromQuery]CalculateAssetAggregateRequest request)
         {
+            request.AssetRegisterVersionId = await GetLatestAssetRegisterVersionIdIfNull(request).ConfigureAwait(false);
+
             var result = await _useCase.ExecuteAsync(request, this.GetCancellationToken()).ConfigureAwait(false);
             return this.StandardiseResponse<CalculateAssetAggregateResponse, AssetAggregatesOutputModel>(result);
+        }
+
+        private async Task<int?> GetLatestAssetRegisterVersionIdIfNull(CalculateAssetAggregateRequest request)
+        {
+            int? assetRegisterVersionId = null;
+            if (request.AssetRegisterVersionId.HasValue)
+                assetRegisterVersionId = request.AssetRegisterVersionId;
+            else
+            {
+                var latestAssetRegister = await _assetRegisterVersionSearcher.Search(new PagedQuery
+                {
+                    Page = 1,
+                    PageSize = 1
+                }, CancellationToken.None).ConfigureAwait(false);
+                assetRegisterVersionId = latestAssetRegister?.Results?.ElementAtOrDefault(0)?.Id;
+            }
+
+            return assetRegisterVersionId;
         }
     }
 }

--- a/WebApi/Controllers/Search/SearchAssetController.cs
+++ b/WebApi/Controllers/Search/SearchAssetController.cs
@@ -55,7 +55,9 @@ namespace WebApi.Controllers.Search
         {
             int? assetRegisterVersionId = null;
             if (request.AssetRegisterVersionId.HasValue)
+            {
                 assetRegisterVersionId = request.AssetRegisterVersionId;
+            }
             else
             {
                 var latestAssetRegister = await _assetRegisterVersionSearcher.Search(new PagedQuery

--- a/WebApi/Controllers/Search/SearchAssetController.cs
+++ b/WebApi/Controllers/Search/SearchAssetController.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.UseCase.GetAsset.Models;
 using HomesEngland.UseCase.SearchAsset;
 using HomesEngland.UseCase.SearchAsset.Models;
@@ -13,10 +17,12 @@ namespace WebApi.Controllers.Search
     public class SearchAssetController : ControllerBase
     {
         private readonly ISearchAssetUseCase _useCase;
+        private readonly IAssetRegisterVersionSearcher _assetRegisterVersionSearcher;
 
-        public SearchAssetController(ISearchAssetUseCase useCase)
+        public SearchAssetController(ISearchAssetUseCase useCase, IAssetRegisterVersionSearcher assetRegisterVersionSearcher)
         {
             _useCase = useCase;
+            _assetRegisterVersionSearcher = assetRegisterVersionSearcher;
         }
 
         [HttpGet("search")]
@@ -29,18 +35,38 @@ namespace WebApi.Controllers.Search
                 return StatusCode(400);
             }
 
-            SearchAssetRequest searchAssetUseCaseRequest = new SearchAssetRequest
+            var assetRegisterVersionId = await GetLatestAssetRegisterVersionIdIfNull(request);
+
+            var searchAssetUseCaseRequest = new SearchAssetRequest
             {
                 SchemeId = request.SchemeId,
                 Address = request.Address,
                 Page = request.Page,
                 PageSize = request.PageSize,
-                AssetRegisterVersionId = request.AssetRegisterVersionId,
+                AssetRegisterVersionId = assetRegisterVersionId,
             };
 
             SearchAssetResponse result = await _useCase
                 .ExecuteAsync(searchAssetUseCaseRequest, this.GetCancellationToken()).ConfigureAwait(false);
             return this.StandardiseResponse<SearchAssetResponse, AssetOutputModel>(result);
+        }
+
+        private async Task<int?> GetLatestAssetRegisterVersionIdIfNull(SearchAssetApiRequest request)
+        {
+            int? assetRegisterVersionId = null;
+            if (request.AssetRegisterVersionId.HasValue)
+                assetRegisterVersionId = request.AssetRegisterVersionId;
+            else
+            {
+                var latestAssetRegister = await _assetRegisterVersionSearcher.Search(new PagedQuery
+                {
+                    Page = 1,
+                    PageSize = 1
+                }, CancellationToken.None).ConfigureAwait(false);
+                assetRegisterVersionId = latestAssetRegister?.Results?.ElementAtOrDefault(0)?.Id;
+            }
+
+            return assetRegisterVersionId;
         }
     }
 }

--- a/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
+++ b/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
@@ -32,16 +32,6 @@ namespace WebApi.Extensions.Requests
                 return false;
             }
 
-            if (AssetRegisterVersionIdIsNull())
-            {
-                return false;
-            }
-
-            if (AssetRegisterVersionIdInvalidIndex())
-            {
-                return false;
-            }
-
             return true;
         }
 

--- a/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Bogus;
 using FluentAssertions;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.UseCase.GetAsset.Models;
 using HomesEngland.UseCase.SearchAsset;
 using HomesEngland.UseCase.SearchAsset.Models;
@@ -22,11 +23,12 @@ namespace WebApiTest.Controller.Asset.Search
     {
         private readonly SearchAssetController _classUnderTest;
         private readonly Mock<ISearchAssetUseCase> _mockUseCase;
+        private readonly Mock<IAssetRegisterVersionSearcher> _mockAssetRegisterVersionSearcher;
 
         public SearchAssetControllerTests()
         {
             _mockUseCase = new Mock<ISearchAssetUseCase>();
-            _classUnderTest = new SearchAssetController(_mockUseCase.Object);
+            _classUnderTest = new SearchAssetController(_mockUseCase.Object, _mockAssetRegisterVersionSearcher.Object);
         }
 
         [Test]


### PR DESCRIPTION
What:
- Default to the latest version of the asset register if none is provided

Why:
- Don't break existing front end implementation