### PR TITLE
[WIP] Use dotnet watch on serve and individual project tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,20 @@ RUN_WEB_SERVICE = $(COMPOSE) run -u $(UID) --rm --service-ports web
 
 test: test-all
 
-test-homes-england: build
-	$(RUN_WEB) dotnet test HomesEnglandTest
+test-acceptance: build
+	$(RUN_WEB) dotnet watch --project AcceptanceTest test
 
 test-homes-england-gateway: build
-	$(RUN_WEB) dotnet test HomesEngland.Gateway.Test
+	$(RUN_WEB) dotnet watch --project HomesEngland.Gateway.Test test
+	
+test-homes-england: build
+	$(RUN_WEB) dotnet watch --project HomesEnglandTest test
 
 test-infrastructure: build
-	$(RUN_WEB) dotnet test InfrastructureTest
+	$(RUN_WEB) dotnet watch --project InfrastructureTest test
 
 test-web-api: build
-	$(RUN_WEB) dotnet test WebApiTest
-
-test-acceptance: build
-	$(RUN_WEB) dotnet test AcceptanceTest
+	$(RUN_WEB) dotnet watch --project WebApiTest test
 
 test-all: build
 	$(RUN_WEB) dotnet test
@@ -36,7 +36,7 @@ setup: build
 	# This is implicit: $(RUN_WEB) dotnet restore
 
 serve: setup
-	$(RUN_WEB_SERVICE) dotnet run --project WebApi
+	$(RUN_WEB_SERVICE) dotnet watch --project WebApi run 
 
 build: docker-build
 
@@ -44,7 +44,6 @@ stop: docker-stop
 
 shell:
 	$(RUN_WEB) bash
-
 
 docker-build:
 	$(COMPOSE) build


### PR DESCRIPTION
WIP until docker IDE intellisense completion can be fixed without requiring `dotnet restore`