### PR TITLE
Feature/filter on region

### DIFF
--- a/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
+++ b/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using FluentAssertions;
+using HomesEngland.Gateway.Migrations;
+using HomesEngland.UseCase.CreateAsset.Models;
+using HomesEngland.UseCase.CreateAssetRegisterVersion;
+using HomesEngland.UseCase.GetAssetRegions;
+using HomesEngland.UseCase.SearchAsset;
+using HomesEngland.UseCase.SearchAsset.Models;
+using Main;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using TestHelper;
+
+namespace AssetRegisterTests.HomesEngland.UseCases.Search.Region
+{
+    [TestFixture]
+    public class GetAssetRegionsUseCaseAcceptanceTests
+    {
+        private readonly ICreateAssetRegisterVersionUseCase _createAssetRegisterVersionUseCase;
+        private readonly IGetAssetRegionsUseCase _classUnderTest;
+
+        public GetAssetRegionsUseCaseAcceptanceTests()
+        {
+            var assetRegister = new AssetRegister();
+
+            _createAssetRegisterVersionUseCase = assetRegister.Get<ICreateAssetRegisterVersionUseCase>();
+            _classUnderTest = assetRegister.Get<IGetAssetRegionsUseCase>();
+
+            var assetRegisterContext = assetRegister.Get<AssetRegisterContext>();
+            assetRegisterContext.Database.Migrate();
+        }
+
+        [TestCase("Region ", 3)]
+        [TestCase("Reg ", 3)]
+        [TestCase("Reggie ",2)]
+        public async Task GivenWeHaveXUniqueRegions_WhenWeGetAllRegions_ThenReturnsXUniqueRegions(string region, int count)
+        {
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var list = new List<CreateAssetRequest>();
+                for (var i = 0; i < count; i++)
+                {
+                    var createAssetRequest = CreateAsset(region + i);
+                    list.Add(createAssetRequest);
+                }
+
+                await _createAssetRegisterVersionUseCase.ExecuteAsync(list, CancellationToken.None).ConfigureAwait(false);
+
+                var response = await _classUnderTest.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                response.Should().NotBeNull();
+                response.Regions.Should().NotBeNullOrEmpty();
+                response.Regions.Count.Should().Be(count);
+            }
+        }
+
+        [TestCase("Region", 3)]
+        [TestCase("Reg", 3)]
+        [TestCase("Reggie", 2)]
+        public async Task GivenWeHaveXRegions_WhenWeGetAllRegions_ThenReturnsUniqueRegions(string region, int count)
+        {
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var list = new List<CreateAssetRequest>();
+                for (var i = 0; i < count; i++)
+                {
+                    var createAssetRequest = CreateAsset(region);
+                    list.Add(createAssetRequest);
+                }
+
+                await _createAssetRegisterVersionUseCase.ExecuteAsync(list, CancellationToken.None).ConfigureAwait(false);
+
+                var response = await _classUnderTest.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
+
+                response.Should().NotBeNull();
+                response.Regions.Should().NotBeNullOrEmpty();
+                response.Regions.Count.Should().Be(1);
+            }
+        }
+
+        private void ExpectFoundAssetIsEqual(SearchAssetResponse foundAsset, CreateAssetResponse createdAsset)
+        {
+            foundAsset.Should().NotBeNull();
+            foundAsset.Assets.Should().NotBeNullOrEmpty();
+            foundAsset.Assets.ElementAt(0).AssetOutputModelIsEqual(createdAsset.Asset);
+        }
+
+        private CreateAssetRequest CreateAsset( string region)
+        {
+            CreateAssetRequest createAssetRequest = TestData.UseCase.GenerateCreateAssetRequest();
+            if (!string.IsNullOrEmpty(region))
+            {
+                createAssetRequest.LocationLaRegionName = region;
+                createAssetRequest.ImsOldRegion = region;
+            }
+                
+            return createAssetRequest;
+        }
+    }
+}

--- a/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
+++ b/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
@@ -93,7 +93,6 @@ namespace AssetRegisterTests.HomesEngland.UseCases.Search.Region
             CreateAssetRequest createAssetRequest = TestData.UseCase.GenerateCreateAssetRequest();
             if (!string.IsNullOrEmpty(region))
             {
-                createAssetRequest.LocationLaRegionName = region;
                 createAssetRequest.ImsOldRegion = region;
             }
                 

--- a/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
+++ b/AcceptanceTest/HomesEngland/UseCases/Search/Region/GetAssetRegionsUseCaseAcceptanceTests.cs
@@ -8,7 +8,6 @@ using HomesEngland.Gateway.Migrations;
 using HomesEngland.UseCase.CreateAsset.Models;
 using HomesEngland.UseCase.CreateAssetRegisterVersion;
 using HomesEngland.UseCase.GetAssetRegions;
-using HomesEngland.UseCase.SearchAsset;
 using HomesEngland.UseCase.SearchAsset.Models;
 using Main;
 using Microsoft.EntityFrameworkCore;

--- a/AcceptanceTest/HomesEngland/UseCases/Search/SearchUseCaseAcceptanceTests.cs
+++ b/AcceptanceTest/HomesEngland/UseCases/Search/SearchUseCaseAcceptanceTests.cs
@@ -53,11 +53,11 @@ namespace AssetRegisterTests.HomesEngland.UseCases.Search
             {
                 var list = new List<CreateAssetRequest>
                 {
-                    CreateAsset(schemeId, address),                    
+                    CreateAsset(schemeId, address),
                 };
 
                 var responses = await _createAssetRegisterVersionUseCase.ExecuteAsync(list, CancellationToken.None).ConfigureAwait(false);
-                
+
                 //act
                 var foundAsset = await SearchForAssetAsync(schemeId, searchAddress, responses.GetAssetRegisterVersionId());
                 //assert
@@ -221,9 +221,9 @@ namespace AssetRegisterTests.HomesEngland.UseCases.Search
             }
         }
 
-        [TestCase( "Region 1", "Regi")]
-        [TestCase( "Region 2", "Regio")]
-        [TestCase( "Region 3", "Region 3")]
+        [TestCase("Region 1", "Regi")]
+        [TestCase("Region 2", "Regio")]
+        [TestCase("Region 3", "Region 3")]
         public async Task GivenAnAssetHasBeenCreated_WhenWeSearchViaRegion_ThenWeCanFindTheSameAsset(string region, string searchRegion)
         {
             //arrange 
@@ -255,7 +255,7 @@ namespace AssetRegisterTests.HomesEngland.UseCases.Search
             {
                 var list = new List<CreateAssetRequest>
                 {
-                    CreateAsset(null, region),
+                    CreateAsset(null, null,region),
                 };
 
                 var responses = await _createAssetRegisterVersionUseCase.ExecuteAsync(list, CancellationToken.None).ConfigureAwait(false);
@@ -267,9 +267,9 @@ namespace AssetRegisterTests.HomesEngland.UseCases.Search
                 //assert
                 ExpectFoundAssetIsEqual(foundAsset, responses[0]);
 
-                trans.Dispose();
-            }
+            trans.Dispose();
         }
+    }
 
         private CreateAssetRequest CreateAsset(int? schemeId, string address, string region = null)
         {

--- a/HomesEngland.Gateway.Test/AssetGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/AssetGatewayTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using FluentAssertions;
 using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.Gateway.Migrations;
 using HomesEngland.Gateway.Sql;
 using Microsoft.EntityFrameworkCore;
@@ -54,6 +55,61 @@ namespace HomesEngland.Gateway.Test
                 var createdAsset = await _classUnderTest.CreateAsync(entity).ConfigureAwait(false);
                 //act
                 var readAsset = await _classUnderTest.ReadAsync(createdAsset.Id).ConfigureAwait(false);
+                //assert
+                readAsset.AssetIsEqual(createdAsset.Id, entity);
+                trans.Dispose();
+            }
+        }
+    }
+
+    [TestFixture]
+    public class GetAssetRegionsGatewayTests
+    {
+        private readonly IAssetRegionLister _classUnderTest;
+        private readonly IGateway<IAsset, int> _gateway;
+
+        public GetAssetRegionsGatewayTests()
+        {
+            var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
+            var assetGateway = new EFAssetGateway(databaseUrl);
+
+            _gateway = assetGateway;
+            _classUnderTest = assetGateway;
+
+            var assetRegisterContext = new AssetRegisterContext(databaseUrl);
+            assetRegisterContext.Database.Migrate();
+        }
+
+        [TestCase("Region 1")]
+        [TestCase("Region 2")]
+        [TestCase("Region 3")]
+        public async Task GivenAnAssetHasBeenCreated_WhenTheAssetIsReadFromTheGateway_ThenItIsTheSame(string region)
+        {
+            //arrange 
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var entity = TestData.Domain.GenerateAsset();
+                entity.ImsOldRegion = region;
+                entity.LocationLaRegionName = region;
+                var createdAsset = await _gateway.CreateAsync(entity).ConfigureAwait(false);
+                //act
+                var regions = await _classUnderTest.ListRegionsAsync(CancellationToken.None).ConfigureAwait(false);
+                //assert
+                regions.Count.Should().Be(1);
+                trans.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task GivenMultipleAssetsHaveBeenCreated_WhenTheAssetsAreReadFromTheGateway_ThenItIsTheSame()
+        {
+            //arrange 
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var entity = TestData.Domain.GenerateAsset();
+                var createdAsset = await _gateway.CreateAsync(entity).ConfigureAwait(false);
+                //act
+                var readAsset = await _gateway.ReadAsync(createdAsset.Id).ConfigureAwait(false);
                 //assert
                 readAsset.AssetIsEqual(createdAsset.Id, entity);
                 trans.Dispose();

--- a/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
@@ -138,7 +138,6 @@ namespace HomesEngland.Gateway.Test
                 entity.Address = address;
             if (!string.IsNullOrEmpty(region))
             {
-                entity.LocationLaRegionName = region;
                 entity.ImsOldRegion = region;
             }
             return entity;
@@ -529,7 +528,6 @@ namespace HomesEngland.Gateway.Test
 
                     var entity = TestData.Domain.GenerateAsset();
                     entity.ImsOldRegion = region;
-                    entity.LocationLaRegionName = region;
                     assets.Add(entity);
                 }
 

--- a/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
@@ -509,5 +509,41 @@ namespace HomesEngland.Gateway.Test
                 trans.Dispose();
             }
         }
+
+        [TestCase("Meow", 1, 3, 3)]
+        [TestCase("Woof", 2, 3, 2)]
+        [TestCase("Moo", 3, 3, 1)]
+        [TestCase("Cluck", 4, 3, 1)]
+        public async Task GivenMultipleAssetsHaveBeenCreated_WhenWeSearchRegionWithPageSize_ReturnCorrectNumberOfPages(string region, int pageSize, int numberOfAssets, int expectedNumberOfPages)
+        {
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var assets = new List<IAsset>();
+                for (var i = 0; i < numberOfAssets; i++)
+                {
+
+                    var entity = TestData.Domain.GenerateAsset();
+                    entity.ImsOldRegion = region;
+                    entity.LocationLaRegionName = region;
+                    assets.Add(entity);
+                }
+
+                var assetRegisterVersion = await CreateAggregatedAssets(assets)
+                    .ConfigureAwait(false);
+
+                var assetQuery = new AssetPagedSearchQuery
+                {
+                    Region = region,
+                    PageSize = pageSize,
+                    AssetRegisterVersionId = assetRegisterVersion.Id
+                };
+
+                var response = await _classUnderTest.Search(assetQuery, CancellationToken.None);
+
+                response.NumberOfPages.Should().Be(expectedNumberOfPages);
+
+                trans.Dispose();
+            }
+        }
     }
 }

--- a/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
@@ -551,10 +551,11 @@ namespace HomesEngland.Gateway.Test
             }
         }
 
-        [TestCase("Region 123", "re ")]
+        [TestCase("Region 123", "re")]
         [TestCase("Region 123", "Reg")]
         [TestCase("Region 123", "Region 1")]
         [TestCase("Region 123", "egion 12")]
+        [TestCase("Region 123", "egion")]
         public async Task GivenMultiplesAssetsHaveBeenCreatedWithTheSameRegion_WhenWeSearch_ThenTheAssetsAreOrderedBySchemeIdDesc(string region, string searchRegion)
         {
             //arrange 
@@ -581,7 +582,7 @@ namespace HomesEngland.Gateway.Test
             }
         }
 
-        [TestCase("Region 123", "re ")]
+        [TestCase("Region 123", "re")]
         [TestCase("Region 123", "Reg")]
         [TestCase("Region 123", "Region 1")]
         [TestCase("Region 123", "egion 12")]

--- a/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/AssetSearchGatewayTests.cs
@@ -129,13 +129,18 @@ namespace HomesEngland.Gateway.Test
             return assetRegisterVersion;
         }
 
-        private IAsset CreateAsset(int? schemeId, string address)
+        private IAsset CreateAsset(int? schemeId, string address, string region = null)
         {
             IAsset entity = TestData.Domain.GenerateAsset();
             if (schemeId.HasValue)
                 entity.SchemeId = schemeId;
             if (!string.IsNullOrEmpty(address))
                 entity.Address = address;
+            if (!string.IsNullOrEmpty(region))
+            {
+                entity.LocationLaRegionName = region;
+                entity.ImsOldRegion = region;
+            }
             return entity;
         }
 
@@ -541,6 +546,65 @@ namespace HomesEngland.Gateway.Test
                 var response = await _classUnderTest.Search(assetQuery, CancellationToken.None);
 
                 response.NumberOfPages.Should().Be(expectedNumberOfPages);
+
+                trans.Dispose();
+            }
+        }
+
+        [TestCase("Region 123", "re ")]
+        [TestCase("Region 123", "Reg")]
+        [TestCase("Region 123", "Region 1")]
+        [TestCase("Region 123", "egion 12")]
+        public async Task GivenMultiplesAssetsHaveBeenCreatedWithTheSameRegion_WhenWeSearch_ThenTheAssetsAreOrderedBySchemeIdDesc(string region, string searchRegion)
+        {
+            //arrange 
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var random = new Random();
+                var randomInt = random.Next();
+                var createdAsset = CreateAsset(randomInt, null, region);
+                var createdAsset2 = CreateAsset(randomInt + 1, null, region);
+                var assetRegisterVersion = await CreateAggregatedAssets(new List<IAsset> { createdAsset, createdAsset2 })
+                    .ConfigureAwait(false);
+                //act
+                var assetSearch = new AssetPagedSearchQuery
+                {
+                    Region = searchRegion,
+                    AssetRegisterVersionId = assetRegisterVersion.Id
+                };
+                //act
+                var assets = await _classUnderTest.Search(assetSearch, CancellationToken.None).ConfigureAwait(false);
+                //assert
+                Assert.Greater(assets.Results.ElementAt(0).SchemeId, assets.Results.ElementAt(1).SchemeId);
+
+                trans.Dispose();
+            }
+        }
+
+        [TestCase("Region 123", "re ")]
+        [TestCase("Region 123", "Reg")]
+        [TestCase("Region 123", "Region 1")]
+        [TestCase("Region 123", "egion 12")]
+        public async Task GivenAnAssetHasBeenCreatedWithTheSameRegion_WhenWeSearch_ThenWeCanFindIt(string region, string searchRegion)
+        {
+            //arrange 
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var random = new Random();
+                var randomInt = random.Next();
+                var createdAsset = CreateAsset(randomInt, null, region);
+                var assetRegisterVersion = await CreateAggregatedAssets(new List<IAsset> { createdAsset })
+                    .ConfigureAwait(false);
+                //act
+                var assetSearch = new AssetPagedSearchQuery
+                {
+                    Region = searchRegion,
+                    AssetRegisterVersionId = assetRegisterVersion.Id
+                };
+                //act
+                var assets = await _classUnderTest.Search(assetSearch, CancellationToken.None).ConfigureAwait(false);
+                //assert
+                assets.Results.Count.Should().Be(1);
 
                 trans.Dispose();
             }

--- a/HomesEngland.Gateway.Test/GetAssetRegionsGatewayTests.cs
+++ b/HomesEngland.Gateway.Test/GetAssetRegionsGatewayTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using FluentAssertions;
 using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.Gateway.Migrations;
 using HomesEngland.Gateway.Sql;
 using Microsoft.EntityFrameworkCore;
@@ -11,33 +14,39 @@ using TestHelper;
 namespace HomesEngland.Gateway.Test
 {
     [TestFixture]
-    public class AssetGatewayTests
+    public class GetAssetRegionsGatewayTests
     {
-        private readonly IGateway<IAsset, int> _classUnderTest;
-        
-        public AssetGatewayTests()
+        private readonly IAssetRegionLister _classUnderTest;
+        private readonly IGateway<IAsset, int> _gateway;
+
+        public GetAssetRegionsGatewayTests()
         {
             var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
             var assetGateway = new EFAssetGateway(databaseUrl);
 
+            _gateway = assetGateway;
             _classUnderTest = assetGateway;
 
             var assetRegisterContext = new AssetRegisterContext(databaseUrl);
             assetRegisterContext.Database.Migrate();
         }
 
-        [Test]
-        public async Task GivenAnAssetHasBeenCreated_WhenTheAssetIsReadFromTheGateway_ThenItIsTheSame()
+        [TestCase("Region 1")]
+        [TestCase("Region 2")]
+        [TestCase("Region 3")]
+        public async Task GivenAnAssetHasBeenCreated_WhenTheAssetIsReadFromTheGateway_ThenItIsTheSame(string region)
         {
             //arrange 
             using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
                 var entity = TestData.Domain.GenerateAsset();
-                var createdAsset = await _classUnderTest.CreateAsync(entity).ConfigureAwait(false);
+                entity.ImsOldRegion = region;
+                entity.LocationLaRegionName = region;
+                var createdAsset = await _gateway.CreateAsync(entity).ConfigureAwait(false);
                 //act
-                var readAsset = await _classUnderTest.ReadAsync(createdAsset.Id).ConfigureAwait(false);
+                var regions = await _classUnderTest.ListRegionsAsync(CancellationToken.None).ConfigureAwait(false);
                 //assert
-                readAsset.AssetIsEqual(createdAsset.Id, entity);
+                regions.Count.Should().Be(1);
                 trans.Dispose();
             }
         }
@@ -49,9 +58,9 @@ namespace HomesEngland.Gateway.Test
             using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
                 var entity = TestData.Domain.GenerateAsset();
-                var createdAsset = await _classUnderTest.CreateAsync(entity).ConfigureAwait(false);
+                var createdAsset = await _gateway.CreateAsync(entity).ConfigureAwait(false);
                 //act
-                var readAsset = await _classUnderTest.ReadAsync(createdAsset.Id).ConfigureAwait(false);
+                var readAsset = await _gateway.ReadAsync(createdAsset.Id).ConfigureAwait(false);
                 //assert
                 readAsset.AssetIsEqual(createdAsset.Id, entity);
                 trans.Dispose();

--- a/HomesEngland.Gateway/Sql/EFAssetGateway.cs
+++ b/HomesEngland.Gateway/Sql/EFAssetGateway.cs
@@ -13,7 +13,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace HomesEngland.Gateway.Sql
 {
-    public class EFAssetGateway : IGateway<IAsset, int>, IAssetReader, IAssetCreator, IAssetSearcher, IAssetAggregator
+    public class EFAssetGateway : IGateway<IAsset, int>, IAssetReader, IAssetCreator, IAssetSearcher, IAssetAggregator, IAssetRegionLister
     {
         private readonly string _databaseUrl; 
 
@@ -127,6 +127,19 @@ namespace HomesEngland.Gateway.Sql
                     MovementInAssetValue = assetValue - moneyPaidOut
                 };
                 return Task.FromResult(assetAggregates);
+            }
+        }
+
+        public Task<IList<AssetRegion>> ListRegionsAsync(CancellationToken cancellationToken)
+        {
+            using (var context = new AssetRegisterContext(_databaseUrl))
+            {
+                IList<AssetRegion> results = context.Assets.Select(s => new AssetRegion
+                {
+                    Name = s.LocationLaRegionName
+                }).Distinct().ToList();
+
+                return Task.FromResult(results);
             }
         }
     }

--- a/HomesEngland.Gateway/Sql/EFAssetGateway.cs
+++ b/HomesEngland.Gateway/Sql/EFAssetGateway.cs
@@ -87,9 +87,7 @@ namespace HomesEngland.Gateway.Sql
 
             if(!string.IsNullOrEmpty(searchRequest.Region) && !string.IsNullOrWhiteSpace(searchRequest.Region))
             {
-                queryable = queryable.Where(w =>
-                    EF.Functions.Like(w.LocationLaRegionName.ToLower(), $"%{searchRequest.Region}%".ToLower()) || 
-                    EF.Functions.Like(w.ImsOldRegion.ToLower(), $"%{searchRequest.Region}%".ToLower()));
+                queryable = queryable.Where(w => EF.Functions.Like(w.ImsOldRegion.ToLower(), $"%{searchRequest.Region}%".ToLower()));
             }
 
             if (searchRequest.SchemeId.HasValue && searchRequest?.SchemeId.Value > 0)
@@ -136,7 +134,7 @@ namespace HomesEngland.Gateway.Sql
             {
                 IList<AssetRegion> results = context.Assets.Select(s => new AssetRegion
                 {
-                    Name = s.LocationLaRegionName
+                    Name = s.ImsOldRegion
                 }).Distinct().ToList();
 
                 return Task.FromResult(results);

--- a/HomesEngland.Gateway/Sql/EFAssetGateway.cs
+++ b/HomesEngland.Gateway/Sql/EFAssetGateway.cs
@@ -85,6 +85,13 @@ namespace HomesEngland.Gateway.Sql
                     EF.Functions.Like(w.Address.ToLower(), $"%{searchRequest.Address}%".ToLower()));
             }
 
+            if(!string.IsNullOrEmpty(searchRequest.Region) && !string.IsNullOrWhiteSpace(searchRequest.Region))
+            {
+                queryable = queryable.Where(w =>
+                    EF.Functions.Like(w.LocationLaRegionName.ToLower(), $"%{searchRequest.Region}%".ToLower()) || 
+                    EF.Functions.Like(w.ImsOldRegion.ToLower(), $"%{searchRequest.Region}%".ToLower()));
+            }
+
             if (searchRequest.SchemeId.HasValue && searchRequest?.SchemeId.Value > 0)
             {
                 queryable = queryable.Where(w => w.SchemeId.HasValue && w.SchemeId == searchRequest.SchemeId.Value);

--- a/HomesEngland/Domain/AssetRegion.cs
+++ b/HomesEngland/Domain/AssetRegion.cs
@@ -1,0 +1,7 @@
+﻿namespace HomesEngland.Domain
+{
+    public class AssetRegion:IAssetRegion
+    {
+        public string Name { get; set; }
+    }
+}

--- a/HomesEngland/Domain/IAssetRegion.cs
+++ b/HomesEngland/Domain/IAssetRegion.cs
@@ -1,0 +1,7 @@
+﻿namespace HomesEngland.Domain
+{
+    public interface IAssetRegion
+    {
+        string Name { get; set; }
+    }
+}

--- a/HomesEngland/Domain/IAssetSearchQuery.cs
+++ b/HomesEngland/Domain/IAssetSearchQuery.cs
@@ -5,5 +5,6 @@
         int? SchemeId { get; set; }
         string Address { get; set; }
         int? AssetRegisterVersionId { get; set; }
+        string Region { get; set; }
     }
 }

--- a/HomesEngland/Gateway/AssetRegisterVersions/IAssetRegionLister.cs
+++ b/HomesEngland/Gateway/AssetRegisterVersions/IAssetRegionLister.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+
+namespace HomesEngland.Gateway.AssetRegisterVersions
+{
+    public interface IAssetRegionLister
+    {
+        Task<IList<AssetRegion>> ListRegionsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/HomesEngland/Gateway/AssetRegisterVersions/IAssetRegisterVersionSearcher.cs
+++ b/HomesEngland/Gateway/AssetRegisterVersions/IAssetRegisterVersionSearcher.cs
@@ -1,4 +1,5 @@
-﻿using HomesEngland.Domain;
+﻿using System.Collections;
+using HomesEngland.Domain;
 using HomesEngland.UseCase.CreateAssetRegisterVersion.Models;
 
 namespace HomesEngland.Gateway.AssetRegisterVersions

--- a/HomesEngland/Gateway/Assets/Region/AssetRegionsResponse.cs
+++ b/HomesEngland/Gateway/Assets/Region/AssetRegionsResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using HomesEngland.Domain;
+
+namespace HomesEngland.Gateway.Assets.Region
+{
+    public class AssetRegionsResponse
+    {
+        public IList<IAssetRegion> Regions { get; set; }
+    }
+}

--- a/HomesEngland/Gateway/Assets/Region/IAssetRegionLister.cs
+++ b/HomesEngland/Gateway/Assets/Region/IAssetRegionLister.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+
+namespace HomesEngland.Gateway.Assets.Region
+{
+    public interface IAssetRegionLister
+    {
+        Task<IList<IAssetRegion>> ListRegionsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/HomesEngland/UseCase/CalculateAssetAggregates/Models/AssetSearchQuery.cs
+++ b/HomesEngland/UseCase/CalculateAssetAggregates/Models/AssetSearchQuery.cs
@@ -7,5 +7,6 @@ namespace HomesEngland.UseCase.CalculateAssetAggregates.Models
         public int? SchemeId { get; set; }
         public string Address { get; set; }
         public int? AssetRegisterVersionId { get; set; }
+        public string Region { get; set; }
     }
 }

--- a/HomesEngland/UseCase/GetAssetRegions/IGetAssetRegionsUseCase.cs
+++ b/HomesEngland/UseCase/GetAssetRegions/IGetAssetRegionsUseCase.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using HomesEngland.Boundary.UseCase;
+using HomesEngland.UseCase.GetAssetRegions.Models;
+
+namespace HomesEngland.UseCase.GetAssetRegions
+{
+    public interface IGetAssetRegionsUseCase:IAsyncResponseUseCaseTask<GetAssetRegionsResponse>
+    {
+
+    }
+}

--- a/HomesEngland/UseCase/GetAssetRegions/Impl/GetAssetRegionsUseCase.cs
+++ b/HomesEngland/UseCase/GetAssetRegions/Impl/GetAssetRegionsUseCase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using HomesEngland.UseCase.GetAssetRegions.Models;
+
+namespace HomesEngland.UseCase.GetAssetRegions.Impl
+{
+    public class GetAssetRegionsUseCase : IGetAssetRegionsUseCase
+    {
+        public Task<GetAssetRegionsResponse> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/HomesEngland/UseCase/GetAssetRegions/Impl/GetAssetRegionsUseCase.cs
+++ b/HomesEngland/UseCase/GetAssetRegions/Impl/GetAssetRegionsUseCase.cs
@@ -1,15 +1,28 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.UseCase.GetAssetRegions.Models;
 
 namespace HomesEngland.UseCase.GetAssetRegions.Impl
 {
     public class GetAssetRegionsUseCase : IGetAssetRegionsUseCase
     {
-        public Task<GetAssetRegionsResponse> ExecuteAsync(CancellationToken cancellationToken)
+        private readonly IAssetRegionLister _assetRegionLister;
+
+        public GetAssetRegionsUseCase(IAssetRegionLister assetRegionLister)
         {
-            throw new NotImplementedException();
+            _assetRegionLister = assetRegionLister;
+        }
+
+        public async Task<GetAssetRegionsResponse> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            var regions = await _assetRegionLister.ListRegionsAsync(cancellationToken).ConfigureAwait(false);
+            var response = new GetAssetRegionsResponse
+            {
+                Regions = regions
+            };
+            return response;
         }
     }
 }

--- a/HomesEngland/UseCase/GetAssetRegions/Models/GetAssetRegionsResponse.cs
+++ b/HomesEngland/UseCase/GetAssetRegions/Models/GetAssetRegionsResponse.cs
@@ -1,10 +1,15 @@
 ﻿using System.Collections.Generic;
 using HomesEngland.Domain;
+using HomesEngland.UseCase.Models;
 
 namespace HomesEngland.UseCase.GetAssetRegions.Models
 {
-    public class GetAssetRegionsResponse
+    public class GetAssetRegionsResponse:IResponse<AssetRegion>
     {
         public IList<AssetRegion> Regions { get; set; }
+        public IList<AssetRegion> ToCsv()
+        {
+            return Regions;
+        }
     }
 }

--- a/HomesEngland/UseCase/GetAssetRegions/Models/GetAssetRegionsResponse.cs
+++ b/HomesEngland/UseCase/GetAssetRegions/Models/GetAssetRegionsResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using HomesEngland.Domain;
+
+namespace HomesEngland.UseCase.GetAssetRegions.Models
+{
+    public class GetAssetRegionsResponse
+    {
+        public IList<AssetRegion> Regions { get; set; }
+    }
+}

--- a/HomesEngland/UseCase/SearchAsset/Impl/SearchAssetUseCase.cs
+++ b/HomesEngland/UseCase/SearchAsset/Impl/SearchAssetUseCase.cs
@@ -40,6 +40,7 @@ namespace HomesEngland.UseCase.SearchAsset.Impl
                           {
                               SchemeId = request.SchemeId,
                               Address = request.Address,
+                              Region = request.Region,
                               AssetRegisterVersionId = request.AssetRegisterVersionId
                           };
 

--- a/HomesEngland/UseCase/SearchAsset/Models/AssetPagedSearchQuery.cs
+++ b/HomesEngland/UseCase/SearchAsset/Models/AssetPagedSearchQuery.cs
@@ -9,5 +9,6 @@ namespace HomesEngland.UseCase.SearchAsset.Models
         public int? PageSize { get; set; } = 25;
         public string Address { get; set; }
         public int? AssetRegisterVersionId { get; set; }
+        public string Region { get; set; }
     }
 }

--- a/HomesEngland/UseCase/SearchAsset/Models/SearchAssetRequest.cs
+++ b/HomesEngland/UseCase/SearchAsset/Models/SearchAssetRequest.cs
@@ -7,6 +7,7 @@
         public int? PageSize { get; set; }
         public string Address { get; set; }
         public int? AssetRegisterVersionId { get; set; }
+        public string Region { get; set; }
 
         public SearchAssetRequest()
         {

--- a/HomesEnglandTest/UseCase/GetAssetRegions/GetAssetRegionsUseCaseTests.cs
+++ b/HomesEnglandTest/UseCase/GetAssetRegions/GetAssetRegionsUseCaseTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
+using HomesEngland.UseCase.GetAssetRegions;
+using HomesEngland.UseCase.GetAssetRegions.Impl;
+using Moq;
+using NUnit.Framework;
+
+namespace HomesEnglandTest.UseCase.GetAssetRegions
+{
+
+    [TestFixture]
+    public class GetAssetRegionsUseCaseTests
+    {
+        private IGetAssetRegionsUseCase _classUnderTest;
+        private Mock<IAssetRegionLister> _mockGateway;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockGateway = new Mock<IAssetRegionLister>();
+            _classUnderTest = new GetAssetRegionsUseCase(_mockGateway.Object);
+        }
+
+        [Test]
+        public async Task WhenWeExecute_ThenWeCallGateways()
+        {
+            //arrange
+            _mockGateway.Setup(s => s.ListRegionsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<AssetRegion>());
+            //act
+            var response = await _classUnderTest.ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+            //assert
+            response.Should().NotBeNull();
+            _mockGateway.Verify(v => v.ListRegionsAsync(It.IsAny<CancellationToken>()));
+        }
+
+        [Test]
+        public async Task GivenTheGatewayReturnsResults_WhenWeExecute_ThenTheResultsAreReturned()
+        {
+            //arrange
+            _mockGateway.Setup(s => s.ListRegionsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<AssetRegion>
+            {
+                new AssetRegion(),
+                new AssetRegion()
+            });
+            //act
+            var response = await _classUnderTest.ExecuteAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+            //assert
+            response.Should().NotBeNull();
+            response.Regions.Count.Should().Be(2);
+        }
+    }
+}

--- a/HomesEnglandTest/UseCase/SearchAsset/SearchAssetTests.cs
+++ b/HomesEnglandTest/UseCase/SearchAsset/SearchAssetTests.cs
@@ -297,5 +297,25 @@ namespace HomesEnglandTest.UseCase.SearchAsset
             response.Should().NotBeNull();
             response.Assets.Should().BeNullOrEmpty();
         }
+
+        [TestCase("Region1")]
+        [TestCase("Region2")]
+        [TestCase("Region3")]
+        public async Task GivenValidAddressAndPageSize_UseCaseCallsGatewayWithPageSize(string region)
+        {
+            var asset = TestData.Domain.GenerateAsset();
+            asset.LocationLaRegionName = region;
+            asset.ImsOldRegion = region;
+            _mockGateway.Search(Arg.Any<IAssetPagedSearchQuery>(), CancellationToken.None).Returns(new PagedResults<IAsset>
+                { Results = new List<IAsset> { asset } });
+
+            await _classUnderTest.ExecuteAsync(new SearchAssetRequest
+            {
+                Region = region
+            }, CancellationToken.None);
+
+            await _mockGateway.Received()
+                .Search(Arg.Is<AssetPagedSearchQuery>(req => req.Region == region), Arg.Any<CancellationToken>());
+        }
     }
 }

--- a/Main/AssetRegister.cs
+++ b/Main/AssetRegister.cs
@@ -31,6 +31,8 @@ using HomesEngland.UseCase.GetAccessToken;
 using HomesEngland.UseCase.GetAccessToken.Impl;
 using HomesEngland.UseCase.GetAsset;
 using HomesEngland.UseCase.GetAsset.Impl;
+using HomesEngland.UseCase.GetAssetRegions;
+using HomesEngland.UseCase.GetAssetRegions.Impl;
 using HomesEngland.UseCase.GetAssetRegisterVersions;
 using HomesEngland.UseCase.GetAssetRegisterVersions.Impl;
 using HomesEngland.UseCase.ImportAssets;
@@ -126,6 +128,10 @@ namespace Main
             RegisterExportedDependency<IAssetRegisterVersionSearcher>(() => new EFAssetRegisterVersionGateway(databaseUrl));
 
             RegisterExportedSingletonDependency<IBackgroundProcessor, BackgroundProcessor>();
+
+            RegisterExportedDependency<IAssetRegionLister>(() => new EFAssetGateway(databaseUrl));
+
+            RegisterExportedDependency<IGetAssetRegionsUseCase, GetAssetRegionsUseCase>();
         }
 
         public override T Get<T>()

--- a/WebApi/Controllers/Search/Filters/SearchFiltersController.cs
+++ b/WebApi/Controllers/Search/Filters/SearchFiltersController.cs
@@ -1,27 +1,21 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using HomesEngland.Domain;
-using HomesEngland.Gateway.AssetRegisterVersions;
-using HomesEngland.UseCase.CalculateAssetAggregates.Models;
 using HomesEngland.UseCase.GetAssetRegions;
 using HomesEngland.UseCase.GetAssetRegions.Models;
 using Microsoft.AspNetCore.Mvc;
 using WebApi.Extensions;
 
-namespace WebApi.Controllers.Search
+namespace WebApi.Controllers.Search.Filters
 {
     [Route("api/v1/asset/search/filters")]
     [ApiController]
     public class SearchFiltersController : ControllerBase
     {
-        private readonly IGetAssetRegionsUseCase _assetRegionUseCaseLister;
+        private readonly IGetAssetRegionsUseCase _assetRegionsUseCase;
 
-
-        public SearchFiltersController(IGetAssetRegionsUseCase assetRegionUseCaseLister)
+        public SearchFiltersController(IGetAssetRegionsUseCase assetRegionsUseCase)
         {
-            _assetRegionUseCaseLister = assetRegionUseCaseLister;
+            _assetRegionsUseCase = assetRegionsUseCase;
         }
 
         [HttpGet("regions")]
@@ -29,8 +23,8 @@ namespace WebApi.Controllers.Search
         [ProducesResponseType(typeof(ResponseData<GetAssetRegionsResponse>), 200)]
         public async Task<IActionResult> Get()
         {
-            throw new NotImplementedException();
+            var response = await _assetRegionsUseCase.ExecuteAsync(this.GetCancellationToken()).ConfigureAwait(false);
+            return this.StandardiseResponse<GetAssetRegionsResponse, AssetRegion>(response);
         }
     }
-
 }

--- a/WebApi/Controllers/Search/SearchFiltersController.cs
+++ b/WebApi/Controllers/Search/SearchFiltersController.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using HomesEngland.Domain;
 using HomesEngland.Gateway.AssetRegisterVersions;
 using HomesEngland.UseCase.CalculateAssetAggregates.Models;
+using HomesEngland.UseCase.GetAssetRegions;
+using HomesEngland.UseCase.GetAssetRegions.Models;
 using Microsoft.AspNetCore.Mvc;
 using WebApi.Extensions;
 
@@ -13,20 +16,20 @@ namespace WebApi.Controllers.Search
     [ApiController]
     public class SearchFiltersController : ControllerBase
     {
-        private readonly IAssetRegionLister _assetRegionLister;
+        private readonly IGetAssetRegionsUseCase _assetRegionUseCaseLister;
 
-        public SearchFiltersController(IAssetRegionLister assetRegionLister)
+
+        public SearchFiltersController(IGetAssetRegionsUseCase assetRegionUseCaseLister)
         {
-            _assetRegionLister = assetRegionLister;
+            _assetRegionUseCaseLister = assetRegionUseCaseLister;
         }
 
         [HttpGet("regions")]
         [Produces("application/json", "text/csv")]
-        [ProducesResponseType(typeof(ResponseData<List<AssetRegion>>), 200)]
+        [ProducesResponseType(typeof(ResponseData<GetAssetRegionsResponse>), 200)]
         public async Task<IActionResult> Get()
         {
-            var result = await _assetRegionLister.ListRegionsAsync(this.GetCancellationToken()).ConfigureAwait(false);
-            return this.StandardiseResponse<CalculateAssetAggregateResponse, AssetAggregatesOutputModel>(result);
+            throw new NotImplementedException();
         }
     }
 

--- a/WebApi/Controllers/Search/SearchFiltersController.cs
+++ b/WebApi/Controllers/Search/SearchFiltersController.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HomesEngland.Domain;
+using HomesEngland.Gateway.AssetRegisterVersions;
+using HomesEngland.UseCase.CalculateAssetAggregates.Models;
+using Microsoft.AspNetCore.Mvc;
+using WebApi.Extensions;
+
+namespace WebApi.Controllers.Search
+{
+    [Route("api/v1/asset/search/filters")]
+    [ApiController]
+    public class SearchFiltersController : ControllerBase
+    {
+        private readonly IAssetRegionLister _assetRegionLister;
+
+        public SearchFiltersController(IAssetRegionLister assetRegionLister)
+        {
+            _assetRegionLister = assetRegionLister;
+        }
+
+        [HttpGet("regions")]
+        [Produces("application/json", "text/csv")]
+        [ProducesResponseType(typeof(ResponseData<List<AssetRegion>>), 200)]
+        public async Task<IActionResult> Get()
+        {
+            var result = await _assetRegionLister.ListRegionsAsync(this.GetCancellationToken()).ConfigureAwait(false);
+            return this.StandardiseResponse<CalculateAssetAggregateResponse, AssetAggregatesOutputModel>(result);
+        }
+    }
+
+}

--- a/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
+++ b/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
@@ -13,17 +13,12 @@ namespace WebApi.Extensions.Requests
 
         public bool IsValid()
         {
-            if (InvalidSchemeID())
+            if (AreAllFiltersNullEmptyOrWhiteSpace())
             {
                 return false;
             }
 
-            if (SchemeIsNullAndAddressIsEmpty() && IsRegionEmpty())
-            {
-                return false;
-            }
-
-                if (!ValidPage())
+            if (!ValidPage())
             {
                 return false;
             }
@@ -32,8 +27,6 @@ namespace WebApi.Extensions.Requests
             {
                 return false;
             }
-
-            
 
             return true;
         }
@@ -48,14 +41,9 @@ namespace WebApi.Extensions.Requests
             return Page == null || Page > 0;
         }
 
-        private bool InvalidSchemeID()
-        {
-            return SchemeIsNullAndAddressIsEmpty() || SchemeIdInvalidIndex();
-        }
-
         private bool SchemeIdInvalidIndex()
         {
-            return SchemeId != null && SchemeId <= 0;
+            return SchemeId == null || SchemeId <= 0;
         }
 
         private bool AssetRegisterVersionIdIsNull()
@@ -63,25 +51,29 @@ namespace WebApi.Extensions.Requests
             return AssetRegisterVersionId == null;
         }
 
-
         private bool AssetRegisterVersionIdInvalidIndex()
         {
             return AssetRegisterVersionId != null && AssetRegisterVersionId <= 0;
         }
 
-        private bool SchemeIsNullAndAddressIsEmpty()
+        private bool AreAllFiltersNullEmptyOrWhiteSpace()
         {
-            return SchemeId == null && IsEmptyAddress() ;
+            var isInvalidSchemeId =  SchemeIdInvalidIndex();
+            var isInvalidAddress = IsEmptyAddress();
+            var isInvalidRegion = IsRegionEmpty();
+            return isInvalidSchemeId && isInvalidAddress && isInvalidRegion;
         }
 
         private bool IsEmptyAddress()
         {
-            return (string.IsNullOrEmpty(Address) || string.IsNullOrWhiteSpace(Address));
+            var isAddressNullEmptyOrWhiteSpace = string.IsNullOrEmpty(Address) || string.IsNullOrWhiteSpace(Address);
+            return isAddressNullEmptyOrWhiteSpace;
         }
 
         private bool IsRegionEmpty()
         {
-            return (string.IsNullOrEmpty(Region) || string.IsNullOrWhiteSpace(Region));
+            var isNullOrEmptyOrWhiteSpace = string.IsNullOrEmpty(Region) || string.IsNullOrWhiteSpace(Region);
+            return isNullOrEmptyOrWhiteSpace;
         }
     }
 }

--- a/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
+++ b/WebApi/Extensions/Requests/SearchAssetApiRequest.cs
@@ -9,6 +9,7 @@ namespace WebApi.Extensions.Requests
         public string Address { get; set; }
         public int? Page { get; set; }
         public int? PageSize { get; set; }
+        public string Region { get; set; }
 
         public bool IsValid()
         {
@@ -17,12 +18,12 @@ namespace WebApi.Extensions.Requests
                 return false;
             }
 
-            if (SchemeIsNullAndAddressIsEmpty())
+            if (SchemeIsNullAndAddressIsEmpty() && IsRegionEmpty())
             {
                 return false;
             }
 
-            if (!ValidPage())
+                if (!ValidPage())
             {
                 return false;
             }
@@ -31,6 +32,8 @@ namespace WebApi.Extensions.Requests
             {
                 return false;
             }
+
+            
 
             return true;
         }
@@ -68,12 +71,17 @@ namespace WebApi.Extensions.Requests
 
         private bool SchemeIsNullAndAddressIsEmpty()
         {
-            return SchemeId == null && IsEmptyAddress();
+            return SchemeId == null && IsEmptyAddress() ;
         }
 
         private bool IsEmptyAddress()
         {
             return (string.IsNullOrEmpty(Address) || string.IsNullOrWhiteSpace(Address));
+        }
+
+        private bool IsRegionEmpty()
+        {
+            return (string.IsNullOrEmpty(Region) || string.IsNullOrWhiteSpace(Region));
         }
     }
 }

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -30,8 +30,4 @@
     <ProjectReference Include="..\Main\Main.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Controllers\Search\Filters\" />
-  </ItemGroup>
-
 </Project>

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="..\Main\Main.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Controllers\Search\Filters\" />
+  </ItemGroup>
+
 </Project>

--- a/WebApiTest/Controller/Asset/Search/Filters/SearchFiltersControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Search/Filters/SearchFiltersControllerTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HomesEngland.Domain;
+using HomesEngland.UseCase.GetAssetRegions;
+using HomesEngland.UseCase.GetAssetRegions.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+using WebApi.Controllers.Search.Filters;
+
+namespace WebApiTest.Controller.Asset.Search.Filters
+{
+    [TestFixture]
+    public class SearchFiltersControllerTests
+    {
+        private readonly SearchFiltersController _classUnderTest;
+        private readonly Mock<IGetAssetRegionsUseCase> _mockUseCase;
+        
+
+        public SearchFiltersControllerTests()
+        {
+            _mockUseCase = new Mock<IGetAssetRegionsUseCase>();
+           
+            _classUnderTest = new SearchFiltersController(_mockUseCase.Object);
+        }
+
+        [Test]
+        public async Task GivenValidRequest_ThenReturnsGetAssetResponse()
+        {
+            //arrange
+            _mockUseCase.Setup(s => s.ExecuteAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetAssetRegionsResponse
+                {
+                    Regions = new List<AssetRegion>
+                    {
+                        new AssetRegion()
+                    }
+                });
+            //act
+            var response = await _classUnderTest.Get();
+            //assert
+            response.Should().NotBeNull();
+        }
+
+        [Test]
+        public async Task GivenValidRequest_ThenCallsUseCase()
+        {
+            //arrange
+            _mockUseCase.Setup(s => s.ExecuteAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetAssetRegionsResponse
+                {
+                    Regions = new List<AssetRegion>
+                    {
+                        new AssetRegion()
+                    }
+                });
+            //act
+            await _classUnderTest.Get();
+            //assert
+            _mockUseCase.Verify(v=> v.ExecuteAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task GivenValidRequestWithAcceptTextCsvHeader_ThenReturnsListOfAssetRegions()
+        {
+            //arrange
+            _mockUseCase.Setup(s => s.ExecuteAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new GetAssetRegionsResponse
+                {
+                    Regions = new List<AssetRegion>
+                    {
+                        new AssetRegion()
+                    }
+                });
+
+            _classUnderTest.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            _classUnderTest.ControllerContext.HttpContext.Request.Headers.Add(new KeyValuePair<string, StringValues>("accept", "text/csv"));
+            //act
+            var response = await _classUnderTest.Get().ConfigureAwait(false);
+            //assert
+            response.Should().NotBeNull();
+            var result = response as ObjectResult;
+            result.Should().NotBeNull();
+            result.Value.Should().BeOfType<List<AssetRegion>>();
+        }
+    }
+}

--- a/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
@@ -79,18 +79,19 @@ namespace WebApiTest.Controller.Asset.Search
             result.Value.Should().BeOfType<List<AssetOutputModel>>();
         }
 
-        [TestCase(null, null     , 1, 1)]
-        [TestCase(0   , null     , 1, 1)]
-        [TestCase(-1  , null     , 1, 1)]
-        [TestCase(null, ""       , 1, 1)]
-        [TestCase(null, " "      , 1, 1)]
-        [TestCase(1   , "address",-1, 1)]
-        [TestCase(1   , "address", 0, 1)]
-        [TestCase(1   , "address", 1,-1)]
-        [TestCase(1   , "address", 1, 0)]
-        
+        [TestCase(null, null     , 1, 1,"Region")]
+        [TestCase(0   , null     , 1, 1,"Region")]
+        [TestCase(-1  , null     , 1, 1,"Region")]
+        [TestCase(null, ""       , 1, 1,"Region")]
+        [TestCase(null, " "      , 1, 1,"Region")]
+        [TestCase(1   , "address",-1, 1,"Region")]
+        [TestCase(1   , "address", 0, 1,"Region")]
+        [TestCase(1   , "address", 1,-1,"Region")]
+        [TestCase(1   , "address", 1, 0,"Region")]
+        [TestCase(null, null, 1, 1, "Region")]
+
         public void GivenInvalidRequest_ThenIsInvalid(int? schemeId, string address, int? page,
-            int? pageSize)
+            int? pageSize, string region)
         {
             SearchAssetApiRequest apiRequest = new SearchAssetApiRequest
             {
@@ -98,32 +99,35 @@ namespace WebApiTest.Controller.Asset.Search
                 Address = address,
                 Page = page,
                 PageSize = pageSize,
+                Region = region
             };
             
             apiRequest.IsValid().Should().BeFalse();
         }
         
-        [TestCase(1   , null     ,    1, 1   )]
-        [TestCase(2   , null     ,    1, 1   )]
-        [TestCase(3   , null     ,    1, 1   )]
-        [TestCase(null, "d"      ,    1, 1   )]
-        [TestCase(null, "e"      ,    1, 1   )]
-        [TestCase(null, "t"      ,    1, 1   )]
-        [TestCase(1   , "a"      ,    1, 1   )]
-        [TestCase(2   , "b"      ,    2, 3   )]
-        [TestCase(3   , "c"      ,    3, 5   )]
-        [TestCase(1   , "address", null, 1   )]
-        [TestCase(1   , "address",    1, null)]
-        [TestCase(1   , "address", null, null)]
+        [TestCase(1   , null     ,    1, 1   ,"Region")]
+        [TestCase(2   , null     ,    1, 1   ,"Region")]
+        [TestCase(3   , null     ,    1, 1   ,"Region")]
+        [TestCase(null, "d"      ,    1, 1   ,"Region")]
+        [TestCase(null, "e"      ,    1, 1   ,"Region")]
+        [TestCase(null, "t"      ,    1, 1   ,"Region")]
+        [TestCase(1   , "a"      ,    1, 1   ,"Region")]
+        [TestCase(2   , "b"      ,    2, 3   ,"Region")]
+        [TestCase(3   , "c"      ,    3, 5   ,"Region")]
+        [TestCase(1   , "address", null, 1   ,"Region")]
+        [TestCase(1   , "address",    1, null,"Region")]
+        [TestCase(1   , "address", null, null,"Region")]
+        [TestCase(null, null, 1, 1, null)]
         public void GivenValidRequest_ThenIsValid(int? schemeId, string address, int? page,
-            int? pageSize)
+            int? pageSize, string region)
         {
             SearchAssetApiRequest apiRequest = new SearchAssetApiRequest
             {
                 SchemeId = schemeId,
                 Address = address,
                 Page = page,
-                PageSize = pageSize
+                PageSize = pageSize,
+                Region = region
             };
 
             apiRequest.IsValid().Should().BeTrue();

--- a/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
+++ b/WebApiTest/Controller/Asset/Search/SearchAssetControllerTests.cs
@@ -79,16 +79,18 @@ namespace WebApiTest.Controller.Asset.Search
             result.Value.Should().BeOfType<List<AssetOutputModel>>();
         }
 
-        [TestCase(null, null     , 1, 1,"Region")]
-        [TestCase(0   , null     , 1, 1,"Region")]
-        [TestCase(-1  , null     , 1, 1,"Region")]
-        [TestCase(null, ""       , 1, 1,"Region")]
-        [TestCase(null, " "      , 1, 1,"Region")]
-        [TestCase(1   , "address",-1, 1,"Region")]
-        [TestCase(1   , "address", 0, 1,"Region")]
-        [TestCase(1   , "address", 1,-1,"Region")]
-        [TestCase(1   , "address", 1, 0,"Region")]
-        [TestCase(null, null, 1, 1, "Region")]
+        [TestCase(null, null     , 1, 1,null)]
+        [TestCase(0   , null     , 1, 1,null)]
+        [TestCase(-1  , null     , 1, 1,null)]
+        [TestCase(null, ""       , 1, 1,null)]
+        [TestCase(null, " "      , 1, 1,null)]
+        [TestCase(1   , "address",-1, 1,null)]
+        [TestCase(1   , "address", 0, 1,null)]
+        [TestCase(1   , "address", 1,-1,null)]
+        [TestCase(1   , "address", 1, 0,null)]
+        [TestCase(null, null, 1, 1, "")]
+        [TestCase(null, null, 1, 1, " ")]
+        [TestCase(null, null, 1, 1, null)]
 
         public void GivenInvalidRequest_ThenIsInvalid(int? schemeId, string address, int? page,
             int? pageSize, string region)
@@ -105,21 +107,20 @@ namespace WebApiTest.Controller.Asset.Search
             apiRequest.IsValid().Should().BeFalse();
         }
         
-        [TestCase(1   , null     ,    1, 1   ,"Region")]
-        [TestCase(2   , null     ,    1, 1   ,"Region")]
-        [TestCase(3   , null     ,    1, 1   ,"Region")]
-        [TestCase(null, "d"      ,    1, 1   ,"Region")]
-        [TestCase(null, "e"      ,    1, 1   ,"Region")]
-        [TestCase(null, "t"      ,    1, 1   ,"Region")]
-        [TestCase(1   , "a"      ,    1, 1   ,"Region")]
-        [TestCase(2   , "b"      ,    2, 3   ,"Region")]
-        [TestCase(3   , "c"      ,    3, 5   ,"Region")]
-        [TestCase(1   , "address", null, 1   ,"Region")]
-        [TestCase(1   , "address",    1, null,"Region")]
-        [TestCase(1   , "address", null, null,"Region")]
-        [TestCase(null, null, 1, 1, null)]
-        public void GivenValidRequest_ThenIsValid(int? schemeId, string address, int? page,
-            int? pageSize, string region)
+        [TestCase(1   , null     ,    1, 1   , null)]
+        [TestCase(2   , null     ,    1, 1   , null)]
+        [TestCase(3   , null     ,    1, 1   , null)]
+        [TestCase(null, "d"      ,    1, 1   , null)]
+        [TestCase(null, "e"      ,    1, 1   , null)]
+        [TestCase(null, "t"      ,    1, 1   , null)]
+        [TestCase(1   , "a"      ,    1, 1   , null)]
+        [TestCase(2   , "b"      ,    2, 3   , null)]
+        [TestCase(3   , "c"      ,    3, 5   , null)]
+        [TestCase(1   , "address", null, 1   , null)]
+        [TestCase(1   , "address",    1, null, null)]
+        [TestCase(1   , "address", null, null, null)]
+        [TestCase(null, null     ,    1,    1, "Region")]
+        public void GivenValidRequest_ThenIsValid(int? schemeId, string address, int? page, int? pageSize, string region)
         {
             SearchAssetApiRequest apiRequest = new SearchAssetApiRequest
             {
@@ -127,12 +128,12 @@ namespace WebApiTest.Controller.Asset.Search
                 Address = address,
                 Page = page,
                 PageSize = pageSize,
-                Region = region
+                Region = region,
+                
             };
 
             apiRequest.IsValid().Should().BeTrue();
         }
-
 
         [Test]
         public async Task GivenRequestWithoutAssetRegisterVersion_ThenCallsUseCaseWithMostRecentVersionOfAssetRegister()


### PR DESCRIPTION
What:
- Search on Region
- Get Searchable regions as a List (for purpose of populating dropdown list).

Why:
- Allow finance team to filter by region and gain an understanding of investments via broad geographical area.

Notes:
- Only pulls list of regions from LocationRegionName, which appears to be the newer region name.
- Allows to search on both the older or newer region name.